### PR TITLE
Define Fortify login rate limiter

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -26,6 +26,12 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::twoFactorChallengeView(fn () => view('livewire.auth.two-factor-challenge'));
         Fortify::confirmPasswordView(fn () => view('livewire.auth.confirm-password'));
 
+        RateLimiter::for('login', function (Request $request) {
+            $email = (string) $request->input('email');
+
+            return Limit::perMinute(5)->by($email.$request->ip());
+        });
+
         RateLimiter::for('two-factor', function (Request $request) {
             return Limit::perMinute(5)->by($request->session()->get('login.id'));
         });


### PR DESCRIPTION
## Summary
- register the missing `login` rate limiter in the Fortify service provider to match the throttling middleware

## Testing
- php artisan test *(fails: vendor directory missing and composer install requires GitHub authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c775ce74832389ce87072fa5070d