### PR TITLE
Fix contactos route name

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -43,7 +43,7 @@ Route::middleware(['auth'])->group(function () {
         ->name('two-factor.show');
 
     Route::get('/contactos', [ContactController::class, 'index'])
-        ->name('contacts.index');
+        ->name('contactos.index');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
## Summary
- Correct the contactos route name to match the Blade template link

## Testing
- ⚠️ `php artisan route:list --name=contactos` *(fails: vendor dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d14668548323ad7115d53f4bbbb6