### PR TITLE
Fix contact search to match contacto table schema

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -16,11 +16,10 @@ class ContactController extends Controller
             ->when($search !== '', function ($query) use ($search) {
                 $query->where(function ($contactQuery) use ($search) {
                     $contactQuery
-                        ->where('name', 'like', "%{$search}%")
-                        ->orWhere('nombre', 'like', "%{$search}%")
-                        ->orWhere('phone', 'like', "%{$search}%")
+                        ->where('nombre', 'like', "%{$search}%")
                         ->orWhere('telefono', 'like', "%{$search}%")
-                        ->orWhere('email', 'like', "%{$search}%");
+                        ->orWhere('email', 'like', "%{$search}%")
+                        ->orWhere('mensaje', 'like', "%{$search}%");
                 });
             })
             ->orderByDesc('id')

--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -12,12 +12,12 @@ class Contact extends Model
     protected $table = 'contactos';
 
     protected $fillable = [
-        'name',
+        'inmueble_id',
         'nombre',
         'email',
-        'phone',
         'telefono',
-        'message',
         'mensaje',
+        'estado',
+        'fuente',
     ];
 }

--- a/resources/views/contacts/index.blade.php
+++ b/resources/views/contacts/index.blade.php
@@ -34,7 +34,7 @@
                             </div>
                             <span class="rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-medium text-indigo-300">{{ optional($contact->created_at)->format('d/m/Y') ?? '—' }}</span>
                         </div>
-                        <h2 class="text-lg font-semibold text-gray-100">{{ $contact->name ?? $contact->nombre ?? '—' }}</h2>
+                        <h2 class="text-lg font-semibold text-gray-100">{{ $contact->nombre ?? '—' }}</h2>
                         <dl class="mt-4 space-y-3 text-sm text-gray-300">
                             <div class="flex items-start gap-3">
                                 <dt class="text-gray-500">Correo:</dt>
@@ -42,11 +42,11 @@
                             </div>
                             <div class="flex items-start gap-3">
                                 <dt class="text-gray-500">Teléfono:</dt>
-                                <dd class="flex-1">{{ $contact->phone ?? $contact->telefono ?? '—' }}</dd>
+                                <dd class="flex-1">{{ $contact->telefono ?? '—' }}</dd>
                             </div>
                             <div>
                                 <dt class="text-gray-500 mb-1">Mensaje:</dt>
-                                <dd class="rounded-xl border border-gray-800 bg-gray-950/60 p-3 text-gray-200">{{ $contact->message ?? $contact->mensaje ?? '—' }}</dd>
+                                <dd class="rounded-xl border border-gray-800 bg-gray-950/60 p-3 text-gray-200">{{ $contact->mensaje ?? '—' }}</dd>
                             </div>
                         </dl>
                     </article>


### PR DESCRIPTION
## Summary
- update contacto search filters to use the actual nombre, telefono, email y mensaje columns
- align the Contact model fillable attributes and the contacts index view with the contacto table schema

## Testing
- not run (composer install requires GitHub token in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4d56b00b48323baa1a65c2b3cae78