### PR TITLE
Refine contacts layout and enable contact creation

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Contact;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
@@ -30,5 +31,28 @@ class ContactController extends Controller
             'contacts' => $contacts,
             'search' => $search,
         ]);
+    }
+
+    public function create(Request $request): View
+    {
+        return view('contacts.create', [
+            'prefill' => trim((string) $request->input('prefill')),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string', 'max:255'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'telefono' => ['nullable', 'string', 'max:30'],
+            'mensaje' => ['nullable', 'string'],
+        ]);
+
+        Contact::create($data);
+
+        return redirect()
+            ->route('contactos.index')
+            ->with('status', 'El contacto se registró correctamente.');
     }
 }

--- a/resources/views/components/layouts/admin.blade.php
+++ b/resources/views/components/layouts/admin.blade.php
@@ -40,7 +40,7 @@
         </aside>
 
         <!-- Contenido -->
-        <main class="flex-1 p-6">
+        <main class="flex-1 p-6 flex flex-col">
             {{ $slot }}
         </main>
     </div>

--- a/resources/views/contacts/create.blade.php
+++ b/resources/views/contacts/create.blade.php
@@ -1,0 +1,86 @@
+<x-layouts.admin>
+    <div class="flex flex-1 items-center justify-center">
+        <div class="w-full max-w-2xl space-y-8">
+            <header class="text-center space-y-2">
+                <p class="text-sm uppercase tracking-widest text-indigo-400">Nuevo contacto</p>
+                <h1 class="text-2xl md:text-3xl font-bold">Registrar contacto</h1>
+                <p class="text-gray-400">Completa los datos para agregar un nuevo contacto al sistema.</p>
+            </header>
+
+            <div class="rounded-2xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/30">
+                <form action="{{ route('contactos.store') }}" method="POST" class="space-y-6">
+                    @csrf
+
+                    <div class="space-y-2">
+                        <label for="nombre" class="block text-sm font-medium text-gray-300">Nombre completo<span class="text-red-500">*</span></label>
+                        <input
+                            type="text"
+                            id="nombre"
+                            name="nombre"
+                            value="{{ old('nombre', $prefill) }}"
+                            required
+                            class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            placeholder="Ej. Juan Pérez"
+                        >
+                        @error('nombre')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div class="space-y-2">
+                        <label for="email" class="block text-sm font-medium text-gray-300">Correo electrónico</label>
+                        <input
+                            type="email"
+                            id="email"
+                            name="email"
+                            value="{{ old('email') }}"
+                            class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            placeholder="correo@dominio.com"
+                        >
+                        @error('email')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div class="space-y-2">
+                        <label for="telefono" class="block text-sm font-medium text-gray-300">Teléfono</label>
+                        <input
+                            type="text"
+                            id="telefono"
+                            name="telefono"
+                            value="{{ old('telefono') }}"
+                            class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            placeholder="5512345678"
+                        >
+                        @error('telefono')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div class="space-y-2">
+                        <label for="mensaje" class="block text-sm font-medium text-gray-300">Notas o mensaje</label>
+                        <textarea
+                            id="mensaje"
+                            name="mensaje"
+                            rows="4"
+                            class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            placeholder="Información adicional"
+                        >{{ old('mensaje') }}</textarea>
+                        @error('mensaje')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+                        <a href="{{ route('contactos.index') }}" class="inline-flex items-center justify-center rounded-xl border border-gray-700 px-5 py-3 text-sm font-medium text-gray-300 transition hover:bg-gray-800/60">
+                            Cancelar
+                        </a>
+                        <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-500 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400">
+                            Guardar contacto
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-layouts.admin>

--- a/resources/views/contacts/index.blade.php
+++ b/resources/views/contacts/index.blade.php
@@ -1,62 +1,71 @@
 <x-layouts.admin>
-    <div class="max-w-3xl mx-auto">
-        <div class="text-center mb-8">
-            <h1 class="text-2xl md:text-3xl font-bold mb-2">Contactos</h1>
-            <p class="text-gray-400">Busca por nombre, teléfono o correo para verificar si ya está registrado.</p>
+    <div class="flex flex-1 items-center justify-center">
+        <div class="w-full max-w-4xl space-y-10">
+            <div class="space-y-4 text-center">
+                <p class="text-sm uppercase tracking-widest text-indigo-400">Directorio</p>
+                <h1 class="text-2xl md:text-3xl font-bold">Contactos</h1>
+                <p class="text-gray-400">Busca por nombre, teléfono o correo para verificar si ya está registrado.</p>
+            </div>
+
+            @if (session('status'))
+                <div class="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+                    {{ session('status') }}
+                </div>
+            @endif
+
+            <form action="{{ route('contactos.index') }}" method="GET" class="rounded-2xl border border-gray-800 bg-gray-900/50 p-6 shadow-xl shadow-black/30">
+                <label for="search" class="block text-sm font-medium text-gray-300 mb-3">Buscar contacto</label>
+                <div class="flex flex-col gap-3 sm:flex-row">
+                    <input
+                        type="text"
+                        id="search"
+                        name="search"
+                        value="{{ old('search', $search) }}"
+                        placeholder="Ej. Juan Pérez, 5512345678 o correo@dominio.com"
+                        class="flex-1 rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    >
+                    <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-500 px-5 py-3 font-medium text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400">
+                        🔍
+                        <span>Buscar</span>
+                    </button>
+                </div>
+            </form>
+
+            @if ($contacts->count())
+                <div class="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+                    @foreach ($contacts as $contact)
+                        <article class="rounded-2xl border border-gray-800 bg-gray-900/60 p-5 shadow-lg shadow-black/30">
+                            <div class="mb-4 flex items-center justify-between">
+                                <div>
+                                    <p class="text-xs uppercase tracking-wide text-gray-500">ID contacto</p>
+                                    <p class="font-semibold text-indigo-300">#{{ $contact->id }}</p>
+                                </div>
+                                <span class="rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-medium text-indigo-300">{{ optional($contact->created_at)->format('d/m/Y') ?? '—' }}</span>
+                            </div>
+                            <h2 class="text-lg font-semibold text-gray-100">{{ $contact->nombre ?? '—' }}</h2>
+                            <dl class="mt-4 space-y-3 text-sm text-gray-300">
+                                <div class="flex items-start gap-3">
+                                    <dt class="text-gray-500">Correo:</dt>
+                                    <dd class="flex-1 break-all">{{ $contact->email ?? '—' }}</dd>
+                                </div>
+                                <div class="flex items-start gap-3">
+                                    <dt class="text-gray-500">Teléfono:</dt>
+                                    <dd class="flex-1">{{ $contact->telefono ?? '—' }}</dd>
+                                </div>
+                                <div>
+                                    <dt class="mb-1 text-gray-500">Mensaje:</dt>
+                                    <dd class="rounded-xl border border-gray-800 bg-gray-950/60 p-3 text-gray-200">{{ $contact->mensaje ?? '—' }}</dd>
+                                </div>
+                            </dl>
+                        </article>
+                    @endforeach
+                </div>
+
+                <div class="pt-4">
+                    {{ $contacts->links() }}
+                </div>
+            @endif
         </div>
-
-        <form action="{{ route('contactos.index') }}" method="GET" class="bg-gray-900/50 border border-gray-800 rounded-2xl p-5 shadow-xl">
-            <label for="search" class="block text-sm font-medium text-gray-300 mb-2">Buscar contacto</label>
-            <div class="flex flex-col sm:flex-row gap-3">
-                <input
-                    type="text"
-                    id="search"
-                    name="search"
-                    value="{{ old('search', $search) }}"
-                    placeholder="Ej. Juan Pérez, 5512345678 o correo@dominio.com"
-                    class="flex-1 rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                >
-                <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-500 px-5 py-3 font-medium text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400">
-                    🔍
-                    <span>Buscar</span>
-                </button>
-            </div>
-        </form>
-
-        @if ($contacts->count())
-            <div class="mt-10 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
-                @foreach ($contacts as $contact)
-                    <article class="rounded-2xl border border-gray-800 bg-gray-900/60 p-5 shadow-lg shadow-black/30">
-                        <div class="flex items-center justify-between mb-4">
-                            <div>
-                                <p class="text-xs uppercase tracking-wide text-gray-500">ID contacto</p>
-                                <p class="font-semibold text-indigo-300">#{{ $contact->id }}</p>
-                            </div>
-                            <span class="rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-medium text-indigo-300">{{ optional($contact->created_at)->format('d/m/Y') ?? '—' }}</span>
-                        </div>
-                        <h2 class="text-lg font-semibold text-gray-100">{{ $contact->nombre ?? '—' }}</h2>
-                        <dl class="mt-4 space-y-3 text-sm text-gray-300">
-                            <div class="flex items-start gap-3">
-                                <dt class="text-gray-500">Correo:</dt>
-                                <dd class="flex-1 break-all">{{ $contact->email ?? '—' }}</dd>
-                            </div>
-                            <div class="flex items-start gap-3">
-                                <dt class="text-gray-500">Teléfono:</dt>
-                                <dd class="flex-1">{{ $contact->telefono ?? '—' }}</dd>
-                            </div>
-                            <div>
-                                <dt class="text-gray-500 mb-1">Mensaje:</dt>
-                                <dd class="rounded-xl border border-gray-800 bg-gray-950/60 p-3 text-gray-200">{{ $contact->mensaje ?? '—' }}</dd>
-                            </div>
-                        </dl>
-                    </article>
-                @endforeach
-            </div>
-
-            <div class="mt-8">
-                {{ $contacts->links() }}
-            </div>
-        @endif
     </div>
 
     @if ($search !== '' && $contacts->isEmpty())
@@ -67,10 +76,18 @@
                         icon: 'info',
                         title: 'Sin resultados',
                         text: 'No encontramos contactos que coincidan con tu búsqueda.',
-                        confirmButtonText: 'Entendido',
+                        confirmButtonText: 'Registrar contacto',
+                        cancelButtonText: 'Cerrar',
+                        showCancelButton: true,
+                    }).then((result) => {
+                        if (result.isConfirmed) {
+                            window.location.href = "{{ route('contactos.create', ['prefill' => $search]) }}";
+                        }
                     });
                 } else {
-                    alert('No encontramos contactos que coincidan con tu búsqueda.');
+                    if (confirm('No encontramos contactos que coincidan con tu búsqueda. ¿Deseas registrar un nuevo contacto?')) {
+                        window.location.href = "{{ route('contactos.create', ['prefill' => $search]) }}";
+                    }
                 }
             });
         </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,6 +44,10 @@ Route::middleware(['auth'])->group(function () {
 
     Route::get('/contactos', [ContactController::class, 'index'])
         ->name('contactos.index');
+    Route::get('/contactos/nuevo', [ContactController::class, 'create'])
+        ->name('contactos.create');
+    Route::post('/contactos', [ContactController::class, 'store'])
+        ->name('contactos.store');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
## Summary
- center the contacts directory content and add status feedback on search results
- prompt users without matches to register and redirect them to a new contact creation form
- add create/store endpoints and a basic form to persist contacts

## Testing
- `php artisan test` *(fails: missing vendor directory before install)*
- `composer install --no-interaction` *(fails: composer cannot clone pestphp/pest-plugin because of blocked GitHub access)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d7a4e3908323b648ed571ca51d95