### PR TITLE
Agregar selector de inmuebles con buscador en el formulario de contactos

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Contact;
+use App\Models\Inmueble;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -37,12 +38,16 @@ class ContactController extends Controller
     {
         return view('contacts.create', [
             'prefill' => trim((string) $request->input('prefill')),
+            'inmuebles' => Inmueble::query()
+                ->orderBy('titulo')
+                ->get(['id', 'titulo', 'direccion', 'operacion', 'tipo']),
         ]);
     }
 
     public function store(Request $request): RedirectResponse
     {
         $data = $request->validate([
+            'inmueble_id' => ['nullable', 'exists:inmuebles,id'],
             'nombre' => ['required', 'string', 'max:255'],
             'email' => ['nullable', 'email', 'max:255'],
             'telefono' => ['nullable', 'string', 'max:30'],

--- a/app/Models/Inmueble.php
+++ b/app/Models/Inmueble.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Inmueble extends Model
+{
+    use HasFactory;
+
+    protected $table = 'inmuebles';
+
+    protected $fillable = [
+        'asesor_id',
+        'titulo',
+        'descripcion',
+        'precio',
+        'direccion',
+        'tipo',
+        'operacion',
+        'estatus_id',
+    ];
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -21,4 +21,48 @@ document.addEventListener("DOMContentLoaded", () => {
             },
         });
     }
+
+    document.querySelectorAll("[data-searchable-select]").forEach((container) => {
+        const searchInput = container.querySelector("[data-search-input]");
+        const select = container.querySelector("select");
+
+        if (!searchInput || !select) {
+            return;
+        }
+
+        const options = Array.from(select.options);
+
+        const filterOptions = () => {
+            const term = searchInput.value.trim().toLowerCase();
+
+            options.forEach((option) => {
+                if (option.value === "") {
+                    option.hidden = false;
+                    return;
+                }
+
+                const searchSource = option.dataset.searchable || option.textContent || "";
+                const matches = term === "" || searchSource.toLowerCase().includes(term);
+
+                option.hidden = !matches;
+            });
+
+            const selectedOption = select.selectedOptions[0];
+            if (selectedOption && selectedOption.hidden) {
+                select.value = "";
+            }
+        };
+
+        searchInput.addEventListener("input", filterOptions);
+
+        searchInput.addEventListener("search", filterOptions);
+
+        searchInput.addEventListener("blur", () => {
+            if (searchInput.value.trim() === "") {
+                options.forEach((option) => {
+                    option.hidden = false;
+                });
+            }
+        });
+    });
 });

--- a/resources/views/contacts/create.blade.php
+++ b/resources/views/contacts/create.blade.php
@@ -1,3 +1,5 @@
+@php use Illuminate\Support\Str; @endphp
+
 <x-layouts.admin>
     <div class="flex flex-1 items-center justify-center">
         <div class="w-full max-w-2xl space-y-8">
@@ -10,6 +12,40 @@
             <div class="rounded-2xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/30">
                 <form action="{{ route('contactos.store') }}" method="POST" class="space-y-6">
                     @csrf
+
+                    <div class="space-y-2">
+                        <label for="inmueble_id" class="block text-sm font-medium text-gray-300">Inmueble asociado</label>
+                        <div class="space-y-2" data-searchable-select>
+                            <input
+                                type="search"
+                                id="inmueble-search"
+                                data-search-input
+                                placeholder="Buscar por título o dirección"
+                                class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                                autocomplete="off"
+                            >
+                            <select
+                                id="inmueble_id"
+                                name="inmueble_id"
+                                class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            >
+                                <option value="">Sin inmueble asociado</option>
+                                @foreach ($inmuebles as $inmueble)
+                                    <option
+                                        value="{{ $inmueble->id }}"
+                                        data-searchable="{{ Str::lower($inmueble->titulo . ' ' . $inmueble->direccion) }}"
+                                        @selected((string) old('inmueble_id') === (string) $inmueble->id)
+                                    >
+                                        {{ $inmueble->titulo }} — {{ $inmueble->direccion }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <p class="text-sm text-gray-400">Utiliza el buscador para filtrar inmuebles por título o dirección.</p>
+                        @error('inmueble_id')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
 
                     <div class="space-y-2">
                         <label for="nombre" class="block text-sm font-medium text-gray-300">Nombre completo<span class="text-red-500">*</span></label>


### PR DESCRIPTION
## Summary
- crear el modelo `Inmueble` para poder listar los inmuebles en el formulario de contactos
- cargar los inmuebles en el controlador de contactos y validar el `inmueble_id`
- añadir al formulario un selector con buscador y la lógica JavaScript para filtrar por título o dirección

## Testing
- `php artisan test` *(falla: faltan dependencias de Composer)*
- `composer install` *(falla: Composer requiere autenticarse contra GitHub para descargar dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_68d4dc8fbd648323bcdf26e6cb6002f4