### PR TITLE
Fix select background in contact creation form

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -64,3 +64,13 @@ select:focus[data-flux-control] {
 /* \[:where(&)\]:size-4 {
     @apply size-4;
 } */
+
+[data-searchable-select] select {
+    background-color: #1f2937;
+    color: #f9fafb;
+}
+
+[data-searchable-select] select option {
+    background-color: #111827;
+    color: #f9fafb;
+}


### PR DESCRIPTION
## Summary
- add custom styles so the searchable select in the contact creation view keeps a dark background for its closed state and dropdown options
- ensure option text remains legible against the new background colors

## Testing
- npm run build *(fails: missing vendor/livewire assets in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e0a6cbf48323b5228ed10bcffbe2