### PR TITLE
Detect search type for contact prefill

### DIFF
--- a/resources/views/contacts/create.blade.php
+++ b/resources/views/contacts/create.blade.php
@@ -21,7 +21,7 @@
                             type="text"
                             id="nombre"
                             name="nombre"
-                            value="{{ old('nombre', $prefill) }}"
+                            value="{{ old('nombre', $prefillField === 'nombre' ? $prefill : '') }}"
                             required
                             class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
                             placeholder="Ej. Juan Pérez"
@@ -37,7 +37,7 @@
                             type="email"
                             id="email"
                             name="email"
-                            value="{{ old('email') }}"
+                            value="{{ old('email', $prefillField === 'email' ? $prefill : '') }}"
                             class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
                             placeholder="correo@dominio.com"
                         >
@@ -52,7 +52,7 @@
                             type="text"
                             id="telefono"
                             name="telefono"
-                            value="{{ old('telefono') }}"
+                            value="{{ old('telefono', $prefillField === 'telefono' ? $prefill : '') }}"
                             class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
                             placeholder="5512345678"
                         >

--- a/resources/views/contacts/index.blade.php
+++ b/resources/views/contacts/index.blade.php
@@ -81,12 +81,12 @@
                         showCancelButton: true,
                     }).then((result) => {
                         if (result.isConfirmed) {
-                            window.location.href = "{{ route('contactos.create', ['prefill' => $search]) }}";
+                            window.location.href = "{{ route('contactos.create', ['prefill' => $search, 'prefill_field' => $searchPrefillField]) }}";
                         }
                     });
                 } else {
                     if (confirm('No encontramos contactos que coincidan con tu búsqueda. ¿Deseas registrar un nuevo contacto?')) {
-                        window.location.href = "{{ route('contactos.create', ['prefill' => $search]) }}";
+                        window.location.href = "{{ route('contactos.create', ['prefill' => $search, 'prefill_field' => $searchPrefillField]) }}";
                     }
                 }
             });


### PR DESCRIPTION
## Summary
- detect the type of value entered in the contact search and expose it to the view
- pass the detected type to the create form so the correct field is prefilled when registering a new contact
- update the create view to prefill the name, email or phone input depending on the detected type

## Testing
- php artisan test *(fails: missing Composer dependencies and GitHub authentication is required to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e4fb204c8323a7eba2e10d336c28