### PR TITLE
Show loader when registering a contact

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -80,4 +80,25 @@ document.addEventListener("DOMContentLoaded", () => {
             }
         });
     });
+
+    document.querySelectorAll("form[data-swal-loader]").forEach((form) => {
+        form.addEventListener("submit", () => {
+            if (!window.Swal || form.dataset.submitting === "true") {
+                return;
+            }
+
+            form.dataset.submitting = "true";
+
+            window.Swal.fire({
+                title: "Registrando contacto",
+                text: "Estamos guardando la información...",
+                allowOutsideClick: false,
+                allowEscapeKey: false,
+                showConfirmButton: false,
+                didOpen: () => {
+                    window.Swal.showLoading();
+                },
+            });
+        });
+    });
 });

--- a/resources/views/contacts/create.blade.php
+++ b/resources/views/contacts/create.blade.php
@@ -10,7 +10,12 @@
             </header>
 
             <div class="rounded-2xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/30">
-                <form action="{{ route('contactos.store') }}" method="POST" class="space-y-6">
+                <form
+                    action="{{ route('contactos.store') }}"
+                    method="POST"
+                    class="space-y-6"
+                    data-swal-loader="registrar-contacto"
+                >
                     @csrf
 
                     


### PR DESCRIPTION
## Summary
- add a data attribute on the Registrar contacto form to flag it for loader handling
- display a SweetAlert loading dialog while the contact form is being submitted

## Testing
- npm run build *(fails: missing vendor/livewire/flux/dist/flux.css referenced by Tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e68e5a248323890d9c29c23f238a