### PR TITLE
Actualizar flujo de contactos con comentarios e intereses

### DIFF
--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -4,6 +4,9 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Carbon;
 
 class Contact extends Model
 {
@@ -16,8 +19,47 @@ class Contact extends Model
         'nombre',
         'email',
         'telefono',
-        'mensaje',
         'estado',
         'fuente',
     ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function comentarios(): HasMany
+    {
+        return $this->hasMany(ContactComment::class, 'contacto_id');
+    }
+
+    public function intereses(): HasMany
+    {
+        return $this->hasMany(ContactInterest::class, 'contacto_id');
+    }
+
+    public function latestComment(): HasOne
+    {
+        return $this->hasOne(ContactComment::class, 'contacto_id')->latestOfMany();
+    }
+
+    public function latestInterest(): HasOne
+    {
+        return $this->hasOne(ContactInterest::class, 'contacto_id')->latestOfMany();
+    }
+
+    public function getLastInteractionAtAttribute(): ?Carbon
+    {
+        $timestamps = collect([
+            $this->updated_at,
+            optional($this->latestComment)->created_at,
+            optional($this->latestInterest)->created_at,
+        ])->filter();
+
+        if ($timestamps->isEmpty()) {
+            return null;
+        }
+
+        return $timestamps->max();
+    }
 }

--- a/app/Models/ContactComment.php
+++ b/app/Models/ContactComment.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ContactComment extends Model
+{
+    use HasFactory;
+
+    protected $table = 'comentarios';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'contacto_id',
+        'comentario',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    public function contact(): BelongsTo
+    {
+        return $this->belongsTo(Contact::class, 'contacto_id');
+    }
+}

--- a/app/Models/ContactInterest.php
+++ b/app/Models/ContactInterest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ContactInterest extends Model
+{
+    use HasFactory;
+
+    protected $table = 'intereses';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'contacto_id',
+        'inmueble_id',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    public function contact(): BelongsTo
+    {
+        return $this->belongsTo(Contact::class, 'contacto_id');
+    }
+
+    public function inmueble(): BelongsTo
+    {
+        return $this->belongsTo(Inmueble::class, 'inmueble_id');
+    }
+}

--- a/inmobiliaria sql structure.sql
+++ b/inmobiliaria sql structure.sql
@@ -56,10 +56,10 @@ CREATE TABLE `comentarios` (
 DROP TABLE IF EXISTS `contactos`;
 CREATE TABLE `contactos` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-  `inmueble_id` bigint unsigned NOT NULL,
+  `inmueble_id` bigint unsigned DEFAULT NULL,
   `nombre` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `email` varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `telefono` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email` varchar(150) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `telefono` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `estado` enum('nuevo','en_contacto','convertido') COLLATE utf8mb4_unicode_ci DEFAULT 'nuevo',
   `fuente` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT 'Web',
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,

--- a/resources/views/contacts/create.blade.php
+++ b/resources/views/contacts/create.blade.php
@@ -67,7 +67,7 @@
                     </div>
 
                     <div class="space-y-2">
-                        <label for="inmueble_id" class="block text-sm font-medium text-gray-300">Inmueble asociado</label>
+                        <label for="inmueble_id" class="block text-sm font-medium text-gray-300">Inmueble de interés</label>
                         <div class="space-y-2" data-searchable-select>
                             <input
                                 type="search"
@@ -82,7 +82,7 @@
                                 name="inmueble_id"
                                 class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
                             >
-                                <option value="">Sin inmueble asociado</option>
+                                <option value="">Sin inmueble registrado</option>
                                 @foreach ($inmuebles as $inmueble)
                                     <option
                                         value="{{ $inmueble->id }}"
@@ -94,22 +94,22 @@
                                 @endforeach
                             </select>
                         </div>
-                        <p class="text-sm text-gray-400">Utiliza el buscador para filtrar inmuebles por título o dirección.</p>
+                        <p class="text-sm text-gray-400">Utiliza el buscador para registrar el inmueble de interés que quedará ligado al historial.</p>
                         @error('inmueble_id')
                             <p class="text-sm text-red-400">{{ $message }}</p>
                         @enderror
                     </div>
 
                     <div class="space-y-2">
-                        <label for="mensaje" class="block text-sm font-medium text-gray-300">Notas o mensaje</label>
+                        <label for="comentario" class="block text-sm font-medium text-gray-300">Comentario inicial</label>
                         <textarea
-                            id="mensaje"
-                            name="mensaje"
+                            id="comentario"
+                            name="comentario"
                             rows="4"
                             class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
                             placeholder="Información adicional"
-                        >{{ old('mensaje') }}</textarea>
-                        @error('mensaje')
+                        >{{ old('comentario') }}</textarea>
+                        @error('comentario')
                             <p class="text-sm text-red-400">{{ $message }}</p>
                         @enderror
                     </div>

--- a/resources/views/contacts/index.blade.php
+++ b/resources/views/contacts/index.blade.php
@@ -32,9 +32,9 @@
             </form>
 
             @if ($contacts->count())
-                <div class="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+                <div class="flex flex-col items-stretch gap-5 md:flex-row md:flex-wrap md:justify-center">
                     @foreach ($contacts as $contact)
-                        <article class="rounded-2xl border border-gray-800 bg-gray-900/60 p-5 shadow-lg shadow-black/30">
+                        <article class="w-full max-w-md md:w-80 rounded-2xl border border-gray-800 bg-gray-900/60 p-5 shadow-lg shadow-black/30">
                             <div class="mb-4 flex items-center justify-between">
                                 <div>
                                     <p class="text-xs uppercase tracking-wide text-gray-500">ID contacto</p>
@@ -42,7 +42,10 @@
                                 </div>
                                 <span class="rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-medium text-indigo-300">{{ optional($contact->created_at)->format('d/m/Y') ?? '—' }}</span>
                             </div>
-                            <h2 class="text-lg font-semibold text-gray-100">{{ $contact->nombre ?? '—' }}</h2>
+                            <div class="space-y-2">
+                                <h2 class="text-lg font-semibold text-gray-100">{{ $contact->nombre ?? '—' }}</h2>
+                                <p class="text-sm text-gray-400">Última interacción: {{ optional($contact->last_interaction_at)->format('d/m/Y H:i') ?? 'Sin registros' }}</p>
+                            </div>
                             <dl class="mt-4 space-y-3 text-sm text-gray-300">
                                 <div class="flex items-start gap-3">
                                     <dt class="text-gray-500">Correo:</dt>
@@ -52,11 +55,26 @@
                                     <dt class="text-gray-500">Teléfono:</dt>
                                     <dd class="flex-1">{{ $contact->telefono ?? '—' }}</dd>
                                 </div>
-                                <div>
-                                    <dt class="mb-1 text-gray-500">Mensaje:</dt>
-                                    <dd class="rounded-xl border border-gray-800 bg-gray-950/60 p-3 text-gray-200">{{ $contact->mensaje ?? '—' }}</dd>
+                                <div class="flex items-start gap-3">
+                                    <dt class="text-gray-500">Inmueble de interés:</dt>
+                                    <dd class="flex-1">
+                                        @if (optional($contact->latestInterest)->inmueble)
+                                            {{ $contact->latestInterest->inmueble->titulo }}
+                                        @else
+                                            <span class="text-gray-500">Sin registrar</span>
+                                        @endif
+                                    </dd>
                                 </div>
                             </dl>
+
+                            <div class="mt-6 flex justify-end">
+                                <a
+                                    href="{{ route('contactos.show', $contact) }}"
+                                    class="inline-flex items-center gap-2 rounded-xl border border-indigo-500/60 px-4 py-2 text-sm font-medium text-indigo-200 transition hover:bg-indigo-500/10"
+                                >
+                                    Ver detalle →
+                                </a>
+                            </div>
                         </article>
                     @endforeach
                 </div>

--- a/resources/views/contacts/show.blade.php
+++ b/resources/views/contacts/show.blade.php
@@ -1,0 +1,176 @@
+@php use Illuminate\Support\Str; @endphp
+
+<x-layouts.admin>
+    <div class="flex flex-1 justify-center">
+        <div class="w-full max-w-5xl space-y-8">
+            <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <p class="text-sm uppercase tracking-widest text-indigo-400">Perfil de contacto</p>
+                    <h1 class="text-2xl md:text-3xl font-bold text-gray-100">{{ $contact->nombre ?? 'Contacto sin nombre' }}</h1>
+                    <p class="text-gray-400">Gestiona las interacciones, comentarios e inmuebles de interés registrados.</p>
+                </div>
+                <div class="flex gap-3">
+                    <a href="{{ route('contactos.index') }}" class="inline-flex items-center gap-2 rounded-xl border border-gray-700 px-4 py-2 text-sm font-medium text-gray-300 transition hover:bg-gray-800/60">
+                        ← Volver al directorio
+                    </a>
+                    <a href="{{ route('contactos.create', ['prefill' => $contact->email ?? $contact->telefono ?? $contact->nombre, 'prefill_field' => $contact->email ? 'email' : ($contact->telefono ? 'telefono' : 'nombre')]) }}" class="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400">
+                        ➕ Nuevo contacto
+                    </a>
+                </div>
+            </div>
+
+            @if (session('status'))
+                <div class="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+                    {{ session('status') }}
+                </div>
+            @endif
+
+            <section class="rounded-2xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/30">
+                <div class="flex flex-col gap-6 md:flex-row md:justify-between">
+                    <div class="space-y-4">
+                        <div>
+                            <p class="text-xs uppercase tracking-wide text-gray-500">ID contacto</p>
+                            <p class="text-lg font-semibold text-indigo-300">#{{ $contact->id }}</p>
+                        </div>
+                        <dl class="space-y-2 text-sm text-gray-300">
+                            <div class="flex items-start gap-3">
+                                <dt class="text-gray-500">Correo:</dt>
+                                <dd class="flex-1 break-all">{{ $contact->email ?? '—' }}</dd>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <dt class="text-gray-500">Teléfono:</dt>
+                                <dd class="flex-1">{{ $contact->telefono ?? '—' }}</dd>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <dt class="text-gray-500">Fuente:</dt>
+                                <dd class="flex-1">{{ $contact->fuente ?? 'Web' }}</dd>
+                            </div>
+                        </dl>
+                    </div>
+                    <div class="space-y-2 text-sm text-gray-400">
+                        <p>Registrado el: <span class="font-medium text-gray-200">{{ optional($contact->created_at)->format('d/m/Y H:i') ?? '—' }}</span></p>
+                        <p>Última interacción: <span class="font-medium text-gray-200">{{ optional($contact->last_interaction_at)->format('d/m/Y H:i') ?? 'Sin registros' }}</span></p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="grid gap-8 lg:grid-cols-2">
+                <div class="space-y-6">
+                    <div class="rounded-2xl border border-gray-800 bg-gray-900/60 p-6 shadow-lg shadow-black/30">
+                        <header class="mb-4 flex items-center justify-between">
+                            <div>
+                                <h2 class="text-lg font-semibold text-gray-100">Inmuebles de interés</h2>
+                                <p class="text-sm text-gray-400">Agrega propiedades asociadas a este contacto.</p>
+                            </div>
+                        </header>
+
+                        <form
+                            action="{{ route('contactos.intereses.store', $contact) }}"
+                            method="POST"
+                            class="space-y-4"
+                            data-swal-loader="registrar-interes"
+                        >
+                            @csrf
+                            <div class="space-y-2" data-searchable-select>
+                                <label for="nuevo-inmueble" class="block text-sm font-medium text-gray-300">Agregar inmueble</label>
+                                <input
+                                    type="search"
+                                    id="nuevo-inmueble-buscar"
+                                    data-search-input
+                                    placeholder="Buscar por título o dirección"
+                                    class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                                    autocomplete="off"
+                                >
+                                <select
+                                    id="nuevo-inmueble"
+                                    name="inmueble_id"
+                                    class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                                    required
+                                >
+                                    <option value="" disabled selected>Selecciona un inmueble</option>
+                                    @foreach ($inmuebles as $inmueble)
+                                        <option value="{{ $inmueble->id }}" data-searchable="{{ Str::lower($inmueble->titulo . ' ' . $inmueble->direccion) }}">
+                                            {{ $inmueble->titulo }} — {{ $inmueble->direccion }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                                @error('inmueble_id')
+                                    <p class="text-sm text-red-400">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            <div class="flex justify-end">
+                                <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400">
+                                    Guardar inmueble
+                                </button>
+                            </div>
+                        </form>
+
+                        <div class="mt-6 space-y-4">
+                            @forelse ($contact->intereses as $interes)
+                                <article class="rounded-xl border border-indigo-500/20 bg-indigo-500/5 p-4">
+                                    <h3 class="font-semibold text-indigo-200">{{ optional($interes->inmueble)->titulo ?? 'Inmueble sin título' }}</h3>
+                                    <p class="text-sm text-gray-400">Registrado el {{ optional($interes->created_at)->format('d/m/Y H:i') ?? '—' }}</p>
+                                    @if ($interes->inmueble)
+                                        <p class="mt-2 text-sm text-gray-300">{{ $interes->inmueble->direccion }} · {{ $interes->inmueble->tipo }} en {{ $interes->inmueble->operacion }}</p>
+                                    @endif
+                                </article>
+                            @empty
+                                <p class="text-sm text-gray-400">Aún no se han registrado inmuebles de interés.</p>
+                            @endforelse
+                        </div>
+                    </div>
+                </div>
+
+                <div class="space-y-6">
+                    <div class="rounded-2xl border border-gray-800 bg-gray-900/60 p-6 shadow-lg shadow-black/30">
+                        <header class="mb-4">
+                            <h2 class="text-lg font-semibold text-gray-100">Comentarios</h2>
+                            <p class="text-sm text-gray-400">Registra notas sobre el seguimiento del contacto.</p>
+                        </header>
+
+                        <form
+                            action="{{ route('contactos.comentarios.store', $contact) }}"
+                            method="POST"
+                            class="space-y-4"
+                            data-swal-loader="registrar-comentario"
+                        >
+                            @csrf
+                            <div class="space-y-2">
+                                <label for="nuevo-comentario" class="block text-sm font-medium text-gray-300">Nuevo comentario</label>
+                                <textarea
+                                    id="nuevo-comentario"
+                                    name="comentario"
+                                    rows="4"
+                                    class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                                    placeholder="Escribe aquí tu nota de seguimiento"
+                                    required
+                                ></textarea>
+                                @error('comentario')
+                                    <p class="text-sm text-red-400">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            <div class="flex justify-end">
+                                <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400">
+                                    Guardar comentario
+                                </button>
+                            </div>
+                        </form>
+
+                        <div class="mt-6 space-y-4">
+                            @forelse ($contact->comentarios as $comentario)
+                                <article class="rounded-xl border border-gray-800 bg-gray-950/70 p-4">
+                                    <p class="text-sm text-gray-200">{{ $comentario->comentario }}</p>
+                                    <p class="mt-2 text-xs uppercase tracking-wide text-gray-500">{{ optional($comentario->created_at)->format('d/m/Y H:i') ?? '—' }}</p>
+                                </article>
+                            @empty
+                                <p class="text-sm text-gray-400">Todavía no hay comentarios registrados.</p>
+                            @endforelse
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+</x-layouts.admin>

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,12 @@ Route::middleware(['auth'])->group(function () {
         ->name('contactos.create');
     Route::post('/contactos', [ContactController::class, 'store'])
         ->name('contactos.store');
+    Route::get('/contactos/{contact}', [ContactController::class, 'show'])
+        ->name('contactos.show');
+    Route::post('/contactos/{contact}/comentarios', [ContactController::class, 'storeComment'])
+        ->name('contactos.comentarios.store');
+    Route::post('/contactos/{contact}/intereses', [ContactController::class, 'storeInterest'])
+        ->name('contactos.intereses.store');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
## Summary
- sincronizar el archivo de estructura SQL con los campos opcionales de contactos
- separar el alta de comentarios e inmuebles de interés en modelos y controladores dedicados
- actualizar las vistas de listado, creación y detalle de contactos para reflejar el nuevo flujo y mostrar interacciones

## Testing
- php artisan test *(falló: vendor/autoload.php ausente por restricciones de descarga)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ee71f8d08323be4ca013e48dfa14