### PR TITLE
Stop setting removed inmueble_id on contacts

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -70,7 +70,6 @@ class ContactController extends Controller
 
         DB::transaction(function () use (&$contact, $data) {
             $contact = Contact::create([
-                'inmueble_id' => null,
                 'nombre' => $data['nombre'],
                 'email' => $data['email'] ?? null,
                 'telefono' => $data['telefono'] ?? null,

--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -15,7 +15,6 @@ class Contact extends Model
     protected $table = 'contactos';
 
     protected $fillable = [
-        'inmueble_id',
         'nombre',
         'email',
         'telefono',


### PR DESCRIPTION
## Summary
- stop passing `inmueble_id` when creating contacts because the column no longer exists
- remove the obsolete `inmueble_id` fillable attribute from the Contact model

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f19ee5c48323a8d60d572b18d49c