### PR TITLE
Confirmar eliminación de contactos con SweetAlert

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -101,4 +101,47 @@ document.addEventListener("DOMContentLoaded", () => {
             });
         });
     });
+
+    document.querySelectorAll("form[data-swal-confirm]").forEach((form) => {
+        form.addEventListener("submit", (event) => {
+            if (form.dataset.swalConfirmed === "true") {
+                return;
+            }
+
+            const title = form.dataset.swalTitle || "¿Estás seguro?";
+            const text = form.dataset.swalConfirm || "Esta acción no se puede deshacer.";
+            const confirmButtonText =
+                form.dataset.swalConfirmButton || "Sí, continuar";
+            const cancelButtonText = form.dataset.swalCancelButton || "Cancelar";
+
+            if (!window.Swal) {
+                const shouldSubmit = window.confirm(`${title}\n\n${text}`);
+
+                if (!shouldSubmit) {
+                    event.preventDefault();
+                }
+
+                return;
+            }
+
+            event.preventDefault();
+
+            window.Swal.fire({
+                icon: "warning",
+                title,
+                text,
+                showCancelButton: true,
+                confirmButtonText,
+                cancelButtonText,
+                reverseButtons: true,
+            }).then((result) => {
+                if (!result.isConfirmed) {
+                    return;
+                }
+
+                form.dataset.swalConfirmed = "true";
+                form.submit();
+            });
+        });
+    });
 });

--- a/resources/views/contacts/show.blade.php
+++ b/resources/views/contacts/show.blade.php
@@ -14,7 +14,10 @@
                         action="{{ route('contactos.destroy', $contact) }}"
                         method="POST"
                         class="inline-flex"
-                        onsubmit="return confirm('Esta acción eliminará el contacto y todo su historial. ¿Deseas continuar?');"
+                        data-swal-confirm="Esta acción eliminará el contacto y todo su historial."
+                        data-swal-title="¿Deseas eliminar el contacto?"
+                        data-swal-confirm-button="Sí, eliminar"
+                        data-swal-cancel-button="Cancelar"
                     >
                         @csrf
                         @method('DELETE')


### PR DESCRIPTION
## Summary
- reemplazar el confirm nativo por un flujo con SweetAlert2 para formularios con `data-swal-confirm`
- añadir atributos de datos al formulario de eliminación de contactos para mostrar un mensaje personalizado
- conservar una confirmación básica cuando SweetAlert2 no está disponible

## Testing
- `npm run build` *(fails: Can't resolve '../../vendor/livewire/flux/dist/flux.css')*

------
https://chatgpt.com/codex/tasks/task_e_68d4f4d73a508323aea7637570200689