### PR TITLE
Implement inmueble CRUD with S3 image uploads and UI

### DIFF
--- a/app/Http/Controllers/InmuebleController.php
+++ b/app/Http/Controllers/InmuebleController.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreInmuebleRequest;
+use App\Http\Requests\UpdateInmuebleRequest;
+use App\Models\Inmueble;
+use App\Models\InmuebleStatus;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\View\View;
+
+class InmuebleController extends Controller
+{
+    /**
+     * Display a listing of the properties.
+     */
+    public function index(Request $request): View
+    {
+        $search = trim((string) $request->query('search', ''));
+        $operacion = $request->query('operacion');
+        $estatus = $request->query('estatus');
+
+        $inmueblesQuery = Inmueble::query()
+            ->with(['coverImage', 'status'])
+            ->when($search !== '', function (Builder $query) use ($search): void {
+                $query->where(function (Builder $subQuery) use ($search): void {
+                    $subQuery
+                        ->where('titulo', 'like', "%{$search}%")
+                        ->orWhere('direccion', 'like', "%{$search}%")
+                        ->orWhere('ciudad', 'like', "%{$search}%")
+                        ->orWhere('estado', 'like', "%{$search}%");
+                });
+            })
+            ->when($operacion, fn (Builder $query) => $query->where('operacion', $operacion))
+            ->when($estatus, fn (Builder $query) => $query->where('estatus_id', $estatus))
+            ->orderByDesc('destacado')
+            ->orderByDesc('updated_at');
+
+        /** @var LengthAwarePaginator $inmuebles */
+        $inmuebles = $inmueblesQuery->paginate(12)->withQueryString();
+
+        $statusCatalog = InmuebleStatus::withCount('inmuebles')
+            ->orderBy('orden')
+            ->orderBy('nombre')
+            ->get();
+
+        $totalsQuery = Inmueble::query();
+        $metrics = [
+            'total' => (clone $totalsQuery)->count(),
+            'destacados' => (clone $totalsQuery)->where('destacado', true)->count(),
+        ];
+
+        $operationBreakdown = Inmueble::select('operacion', DB::raw('count(*) as total'))
+            ->groupBy('operacion')
+            ->pluck('total', 'operacion');
+
+        return view('inmuebles.index', [
+            'inmuebles' => $inmuebles,
+            'statuses' => $statusCatalog,
+            'metrics' => $metrics,
+            'operationBreakdown' => $operationBreakdown,
+            'search' => $search,
+            'selectedOperacion' => $operacion,
+            'selectedStatus' => $estatus,
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new property.
+     */
+    public function create(): View
+    {
+        $statuses = InmuebleStatus::orderBy('orden')->orderBy('nombre')->get();
+
+        return view('inmuebles.create', [
+            'statuses' => $statuses,
+            'tipos' => Inmueble::TIPOS,
+            'operaciones' => Inmueble::OPERACIONES,
+        ]);
+    }
+
+    /**
+     * Store a newly created property in storage.
+     */
+    public function store(StoreInmuebleRequest $request): RedirectResponse
+    {
+        $payload = $this->preparePayload($request->validated(), $request);
+        $imagenes = $request->file('imagenes', []);
+
+        DB::transaction(function () use ($payload, $imagenes): void {
+            $inmueble = Inmueble::create($payload);
+
+            $this->storeImages($inmueble, $imagenes);
+        });
+
+        return redirect()
+            ->route('inmuebles.index')
+            ->with('status', 'Inmueble registrado correctamente.');
+    }
+
+    /**
+     * Show the form for editing the specified property.
+     */
+    public function edit(Inmueble $inmueble): View
+    {
+        $inmueble->load('images', 'status');
+        $statuses = InmuebleStatus::orderBy('orden')->orderBy('nombre')->get();
+
+        return view('inmuebles.edit', [
+            'inmueble' => $inmueble,
+            'statuses' => $statuses,
+            'tipos' => Inmueble::TIPOS,
+            'operaciones' => Inmueble::OPERACIONES,
+        ]);
+    }
+
+    /**
+     * Update the specified property in storage.
+     */
+    public function update(UpdateInmuebleRequest $request, Inmueble $inmueble): RedirectResponse
+    {
+        $payload = $this->preparePayload($request->validated(), $request);
+        $imagenes = $request->file('imagenes', []);
+        $imagenesEliminar = collect($request->input('imagenes_eliminar', []))->filter()->all();
+
+        DB::transaction(function () use ($inmueble, $payload, $imagenes, $imagenesEliminar): void {
+            $inmueble->update($payload);
+
+            if (! empty($imagenesEliminar)) {
+                $this->deleteImages($inmueble, $imagenesEliminar);
+            }
+
+            $this->storeImages($inmueble->fresh(), $imagenes);
+        });
+
+        return redirect()
+            ->route('inmuebles.edit', $inmueble)
+            ->with('status', 'Inmueble actualizado correctamente.');
+    }
+
+    /**
+     * Remove the specified property from storage.
+     */
+    public function destroy(Inmueble $inmueble): RedirectResponse
+    {
+        $inmueble->load('images');
+
+        DB::transaction(function () use ($inmueble): void {
+            foreach ($inmueble->images as $image) {
+                Storage::disk($image->disk)->delete($image->path);
+            }
+
+            $inmueble->delete();
+        });
+
+        return redirect()
+            ->route('inmuebles.index')
+            ->with('status', 'Inmueble eliminado correctamente.');
+    }
+
+    /**
+     * Normalize payload to be stored in the database.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    protected function preparePayload(array $payload, Request $request): array
+    {
+        $payload['asesor_id'] = $request->user()->id;
+        $payload['destacado'] = $request->boolean('destacado');
+
+        foreach ([
+            'habitaciones',
+            'banos',
+            'estacionamientos',
+            'metros_cuadrados',
+            'superficie_construida',
+            'superficie_terreno',
+            'anio_construccion',
+        ] as $numericField) {
+            if (! array_key_exists($numericField, $payload)) {
+                continue;
+            }
+
+            if ($payload[$numericField] === '' || $payload[$numericField] === null) {
+                $payload[$numericField] = null;
+            }
+        }
+
+        $payload['amenidades'] = $this->transformListStringToArray($payload['amenidades'] ?? '');
+        $payload['extras'] = $this->transformListStringToArray($payload['extras'] ?? '');
+
+        unset($payload['imagenes']);
+
+        return $payload;
+    }
+
+    /**
+     * Convert textarea values to arrays for storage.
+     *
+     * @return array<int, string>|null
+     */
+    protected function transformListStringToArray(?string $value): ?array
+    {
+        if ($value === null || trim($value) === '') {
+            return null;
+        }
+
+        return collect(preg_split('/\r\n|\r|\n/', (string) $value))
+            ->map(fn (string $item) => trim($item))
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Persist uploaded images in S3 (or the configured disk).
+     *
+     * @param  array<int, \Illuminate\Http\UploadedFile>  $imagenes
+     */
+    protected function storeImages(Inmueble $inmueble, array $imagenes): void
+    {
+        if (empty($imagenes)) {
+            return;
+        }
+
+        $diskName = $this->resolveImageDisk();
+        $disk = Storage::disk($diskName);
+        $basePath = "inmuebles/{$inmueble->id}";
+        $ordenBase = (int) $inmueble->images()->max('orden');
+
+        foreach ($imagenes as $index => $imagen) {
+            $fileName = Str::uuid() . '.' . $imagen->getClientOriginalExtension();
+            $path = $disk->putFileAs($basePath, $imagen, $fileName, ['visibility' => 'public']);
+
+            $inmueble->images()->create([
+                'disk' => $diskName,
+                'path' => $path,
+                'url' => $disk->url($path),
+                'orden' => $ordenBase + $index + 1,
+                'metadata' => [
+                    'original_name' => $imagen->getClientOriginalName(),
+                    'size' => $imagen->getSize(),
+                    'mime_type' => $imagen->getMimeType(),
+                ],
+            ]);
+        }
+    }
+
+    /**
+     * Delete images both from storage and the database.
+     *
+     * @param  array<int, int>  $imagenesIds
+     */
+    protected function deleteImages(Inmueble $inmueble, array $imagenesIds): void
+    {
+        $imagenes = $inmueble->images()->whereIn('id', $imagenesIds)->get();
+
+        foreach ($imagenes as $imagen) {
+            Storage::disk($imagen->disk)->delete($imagen->path);
+            $imagen->delete();
+        }
+    }
+
+    /**
+     * Determine which filesystem disk should be used for property images.
+     */
+    protected function resolveImageDisk(): string
+    {
+        if (config('filesystems.default') === 's3') {
+            return 's3';
+        }
+
+        if (! empty(config('filesystems.disks.s3.bucket'))) {
+            return 's3';
+        }
+
+        return config('filesystems.default', 'public');
+    }
+}

--- a/app/Http/Requests/StoreInmuebleRequest.php
+++ b/app/Http/Requests/StoreInmuebleRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Inmueble;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreInmuebleRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'titulo' => ['required', 'string', 'max:200'],
+            'descripcion' => ['nullable', 'string'],
+            'precio' => ['required', 'numeric', 'min:0', 'max:9999999999.99'],
+            'direccion' => ['required', 'string', 'max:255'],
+            'ciudad' => ['nullable', 'string', 'max:120'],
+            'estado' => ['nullable', 'string', 'max:120'],
+            'codigo_postal' => ['nullable', 'string', 'max:20'],
+            'tipo' => ['required', Rule::in(Inmueble::TIPOS)],
+            'operacion' => ['required', Rule::in(Inmueble::OPERACIONES)],
+            'estatus_id' => ['required', 'integer', Rule::exists('inmueble_estatus', 'id')],
+            'habitaciones' => ['nullable', 'integer', 'min:0', 'max:50'],
+            'banos' => ['nullable', 'integer', 'min:0', 'max:50'],
+            'estacionamientos' => ['nullable', 'integer', 'min:0', 'max:50'],
+            'metros_cuadrados' => ['nullable', 'numeric', 'min:0', 'max:99999.99'],
+            'superficie_construida' => ['nullable', 'numeric', 'min:0', 'max:99999.99'],
+            'superficie_terreno' => ['nullable', 'numeric', 'min:0', 'max:99999.99'],
+            'anio_construccion' => ['nullable', 'integer', 'min:1800', 'max:' . now()->year],
+            'destacado' => ['sometimes', 'boolean'],
+            'video_url' => ['nullable', 'url', 'max:255'],
+            'tour_virtual_url' => ['nullable', 'url', 'max:255'],
+            'amenidades' => ['nullable', 'string', 'max:2000'],
+            'extras' => ['nullable', 'string', 'max:2000'],
+            'imagenes' => ['nullable', 'array', 'max:10'],
+            'imagenes.*' => ['image', 'max:5120'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateInmuebleRequest.php
+++ b/app/Http/Requests/UpdateInmuebleRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Validation\Rule;
+
+class UpdateInmuebleRequest extends StoreInmuebleRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $rules = parent::rules();
+
+        $rules['imagenes'] = ['nullable', 'array', 'max:10'];
+        $rules['imagenes.*'] = ['image', 'max:5120'];
+        $rules['imagenes_eliminar'] = ['nullable', 'array'];
+        $rules['imagenes_eliminar.*'] = [
+            'integer',
+            Rule::exists('inmueble_imagenes', 'id')->where('inmueble_id', $this->route('inmueble')?->id),
+        ];
+
+        return $rules;
+    }
+}

--- a/app/Models/Inmueble.php
+++ b/app/Models/Inmueble.php
@@ -4,10 +4,30 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Carbon;
 
 class Inmueble extends Model
 {
     use HasFactory;
+
+    public const TIPOS = [
+        'Departamento',
+        'Casa',
+        'Oficina',
+        'Local Comercial',
+        'Terreno',
+        'Bodega',
+        'Otro',
+    ];
+
+    public const OPERACIONES = [
+        'Renta',
+        'Venta',
+        'Traspaso',
+    ];
 
     protected $table = 'inmuebles';
 
@@ -17,8 +37,103 @@ class Inmueble extends Model
         'descripcion',
         'precio',
         'direccion',
+        'ciudad',
+        'estado',
+        'codigo_postal',
         'tipo',
         'operacion',
         'estatus_id',
+        'habitaciones',
+        'banos',
+        'estacionamientos',
+        'metros_cuadrados',
+        'superficie_construida',
+        'superficie_terreno',
+        'anio_construccion',
+        'destacado',
+        'video_url',
+        'tour_virtual_url',
+        'amenidades',
+        'extras',
     ];
+
+    protected $casts = [
+        'precio' => 'decimal:2',
+        'habitaciones' => 'integer',
+        'banos' => 'integer',
+        'estacionamientos' => 'integer',
+        'metros_cuadrados' => 'decimal:2',
+        'superficie_construida' => 'decimal:2',
+        'superficie_terreno' => 'decimal:2',
+        'anio_construccion' => 'integer',
+        'destacado' => 'boolean',
+        'amenidades' => 'array',
+        'extras' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    /**
+     * Inmueble belongs to an asesor (user).
+     */
+    public function asesor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'asesor_id');
+    }
+
+    /**
+     * Inmueble belongs to a status catalog entry.
+     */
+    public function status(): BelongsTo
+    {
+        return $this->belongsTo(InmuebleStatus::class, 'estatus_id');
+    }
+
+    /**
+     * All images for the property ordered by the preferred order.
+     */
+    public function images(): HasMany
+    {
+        return $this->hasMany(InmuebleImage::class)->orderBy('orden')->orderBy('id');
+    }
+
+    /**
+     * Convenience relation for the first (cover) image.
+     */
+    public function coverImage(): HasOne
+    {
+        return $this->hasOne(InmuebleImage::class)->orderBy('orden')->orderBy('id');
+    }
+
+    /**
+     * Amenidades formatted as newline separated string.
+     */
+    public function amenidadesAsText(): string
+    {
+        $amenidades = collect($this->amenidades);
+
+        if ($amenidades->isEmpty()) {
+            return '';
+        }
+
+        return $amenidades->join(PHP_EOL);
+    }
+
+    /**
+     * Human readable price representation.
+     */
+    public function formattedPrice(): string
+    {
+        return '$' . number_format((float) $this->precio, 2);
+    }
+
+    /**
+     * Human readable updated at timestamp.
+     */
+    public function lastUpdatedDiff(): ?string
+    {
+        $timestamp = $this->updated_at instanceof Carbon ? $this->updated_at : null;
+
+        return $timestamp?->diffForHumans();
+    }
 }

--- a/app/Models/InmuebleImage.php
+++ b/app/Models/InmuebleImage.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
+
+class InmuebleImage extends Model
+{
+    use HasFactory;
+
+    protected $table = 'inmueble_imagenes';
+
+    protected $fillable = [
+        'inmueble_id',
+        'disk',
+        'path',
+        'url',
+        'orden',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'orden' => 'integer',
+        'metadata' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    /**
+     * Image belongs to an inmueble.
+     */
+    public function inmueble(): BelongsTo
+    {
+        return $this->belongsTo(Inmueble::class);
+    }
+
+    /**
+     * Retrieve the URL using the configured filesystem disk when not stored.
+     */
+    public function getUrlAttribute(?string $value): ?string
+    {
+        if (! empty($value)) {
+            return $value;
+        }
+
+        if (empty($this->path) || empty($this->disk)) {
+            return $value;
+        }
+
+        return Storage::disk($this->disk)->url($this->path);
+    }
+}

--- a/app/Models/InmuebleStatus.php
+++ b/app/Models/InmuebleStatus.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class InmuebleStatus extends Model
+{
+    use HasFactory;
+
+    protected $table = 'inmueble_estatus';
+
+    protected $fillable = [
+        'nombre',
+        'descripcion',
+        'color',
+        'orden',
+    ];
+
+    protected $casts = [
+        'orden' => 'integer',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    /**
+     * All properties assigned to this status.
+     */
+    public function inmuebles(): HasMany
+    {
+        return $this->hasMany(Inmueble::class, 'estatus_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
@@ -58,5 +58,13 @@ class User extends Authenticatable
             ->take(2)
             ->map(fn ($word) => Str::substr($word, 0, 1))
             ->implode('');
+    }
+
+    /**
+     * Properties assigned to the user.
+     */
+    public function inmuebles(): HasMany
+    {
+        return $this->hasMany(Inmueble::class, 'asesor_id');
     }
 }

--- a/database/migrations/2025_10_01_000000_create_inmueble_estatus_table.php
+++ b/database/migrations/2025_10_01_000000_create_inmueble_estatus_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('inmueble_estatus', function (Blueprint $table) {
+            $table->id();
+            $table->string('nombre', 80);
+            $table->string('descripcion', 160)->nullable();
+            $table->string('color', 30)->default('#6366f1');
+            $table->unsignedTinyInteger('orden')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('inmueble_estatus');
+    }
+};

--- a/database/migrations/2025_10_01_000100_create_inmuebles_table.php
+++ b/database/migrations/2025_10_01_000100_create_inmuebles_table.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('inmuebles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('asesor_id')->constrained('users');
+            $table->string('titulo', 200);
+            $table->text('descripcion')->nullable();
+            $table->decimal('precio', 12, 2);
+            $table->string('direccion', 255);
+            $table->string('ciudad', 120)->nullable();
+            $table->string('estado', 120)->nullable();
+            $table->string('codigo_postal', 20)->nullable();
+            $table->enum('tipo', [
+                'Departamento',
+                'Casa',
+                'Oficina',
+                'Local Comercial',
+                'Terreno',
+                'Bodega',
+                'Otro',
+            ]);
+            $table->enum('operacion', ['Renta', 'Venta', 'Traspaso']);
+            $table->unsignedTinyInteger('estatus_id');
+            $table->unsignedTinyInteger('habitaciones')->nullable();
+            $table->unsignedTinyInteger('banos')->nullable();
+            $table->unsignedTinyInteger('estacionamientos')->nullable();
+            $table->decimal('metros_cuadrados', 8, 2)->nullable();
+            $table->decimal('superficie_construida', 8, 2)->nullable();
+            $table->decimal('superficie_terreno', 8, 2)->nullable();
+            $table->unsignedSmallInteger('anio_construccion')->nullable();
+            $table->boolean('destacado')->default(false);
+            $table->string('video_url')->nullable();
+            $table->string('tour_virtual_url')->nullable();
+            $table->json('amenidades')->nullable();
+            $table->json('extras')->nullable();
+            $table->timestamps();
+
+            $table->foreign('estatus_id')->references('id')->on('inmueble_estatus');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('inmuebles');
+    }
+};

--- a/database/migrations/2025_10_01_000200_create_inmueble_imagenes_table.php
+++ b/database/migrations/2025_10_01_000200_create_inmueble_imagenes_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('inmueble_imagenes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('inmueble_id')->constrained('inmuebles')->cascadeOnDelete();
+            $table->string('disk', 50)->default('s3');
+            $table->string('path');
+            $table->string('url');
+            $table->unsignedInteger('orden')->default(0);
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('inmueble_imagenes');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,7 +3,6 @@
 namespace Database\Seeders;
 
 use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,7 +12,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $this->call([
+            InmuebleStatusSeeder::class,
+        ]);
 
         User::factory()->create([
             'name' => 'Test User',

--- a/database/seeders/InmuebleStatusSeeder.php
+++ b/database/seeders/InmuebleStatusSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\InmuebleStatus;
+use Illuminate\Database\Seeder;
+
+class InmuebleStatusSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $statuses = [
+            ['nombre' => 'Disponible', 'descripcion' => 'Listo para mostrar', 'color' => '#10b981', 'orden' => 1],
+            ['nombre' => 'En negociación', 'descripcion' => 'Interés activo', 'color' => '#f97316', 'orden' => 2],
+            ['nombre' => 'Apartado', 'descripcion' => 'Reservado temporalmente', 'color' => '#6366f1', 'orden' => 3],
+            ['nombre' => 'Vendido', 'descripcion' => 'Cerrado exitosamente', 'color' => '#8b5cf6', 'orden' => 4],
+            ['nombre' => 'Rentado', 'descripcion' => 'Contrato activo', 'color' => '#0ea5e9', 'orden' => 5],
+        ];
+
+        foreach ($statuses as $status) {
+            InmuebleStatus::updateOrCreate(
+                ['nombre' => $status['nombre']],
+                $status,
+            );
+        }
+    }
+}

--- a/resources/views/components/inmuebles/form.blade.php
+++ b/resources/views/components/inmuebles/form.blade.php
@@ -1,0 +1,343 @@
+@props([
+    'inmueble' => null,
+    'statuses' => collect(),
+    'tipos' => [],
+    'operaciones' => [],
+])
+
+@php
+    $amenidadesText = old('amenidades', optional($inmueble)->amenidadesAsText());
+    $extrasText = old('extras', optional($inmueble)->extras ? collect($inmueble->extras)->join(PHP_EOL) : '');
+@endphp
+
+<div class="space-y-8">
+    <section class="rounded-3xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/30">
+        <div class="space-y-6">
+            <div>
+                <h2 class="text-lg font-semibold">Información general</h2>
+                <p class="text-sm text-gray-400">Agrega los datos principales del inmueble que se mostrarán en la ficha pública.</p>
+            </div>
+
+            <div class="grid gap-5 lg:grid-cols-2">
+                <div class="space-y-2">
+                    <label for="titulo" class="text-sm font-medium">Título *</label>
+                    <input
+                        type="text"
+                        id="titulo"
+                        name="titulo"
+                        value="{{ old('titulo', optional($inmueble)->titulo) }}"
+                        placeholder="Ej. Departamento moderno con terraza"
+                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        required
+                    >
+                    @error('titulo')
+                        <p class="text-sm text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="space-y-2">
+                    <label for="precio" class="text-sm font-medium">Precio *</label>
+                    <div class="relative">
+                        <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-400">$</span>
+                        <input
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            id="precio"
+                            name="precio"
+                            value="{{ old('precio', optional($inmueble)->precio) }}"
+                            class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 pl-7 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            required
+                        >
+                    </div>
+                    @error('precio')
+                        <p class="text-sm text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+            </div>
+
+            <div class="grid gap-5 lg:grid-cols-2">
+                <div class="space-y-2">
+                    <label for="direccion" class="text-sm font-medium">Dirección *</label>
+                    <input
+                        type="text"
+                        id="direccion"
+                        name="direccion"
+                        value="{{ old('direccion', optional($inmueble)->direccion) }}"
+                        placeholder="Calle y número"
+                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        required
+                    >
+                    @error('direccion')
+                        <p class="text-sm text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                    <div class="space-y-2">
+                        <label for="ciudad" class="text-sm font-medium">Ciudad</label>
+                        <input
+                            type="text"
+                            id="ciudad"
+                            name="ciudad"
+                            value="{{ old('ciudad', optional($inmueble)->ciudad) }}"
+                            class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        >
+                        @error('ciudad')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+                    <div class="space-y-2">
+                        <label for="estado" class="text-sm font-medium">Estado</label>
+                        <input
+                            type="text"
+                            id="estado"
+                            name="estado"
+                            value="{{ old('estado', optional($inmueble)->estado) }}"
+                            class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        >
+                        @error('estado')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+                    <div class="space-y-2">
+                        <label for="codigo_postal" class="text-sm font-medium">C.P.</label>
+                        <input
+                            type="text"
+                            id="codigo_postal"
+                            name="codigo_postal"
+                            value="{{ old('codigo_postal', optional($inmueble)->codigo_postal) }}"
+                            class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        >
+                        @error('codigo_postal')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+                </div>
+            </div>
+
+            <div class="grid gap-5 lg:grid-cols-3">
+                <div class="space-y-2">
+                    <label for="tipo" class="text-sm font-medium">Tipo *</label>
+                    <select
+                        id="tipo"
+                        name="tipo"
+                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        required
+                    >
+                        <option value="">Selecciona una opción</option>
+                        @foreach ($tipos as $tipo)
+                            <option value="{{ $tipo }}" @selected(old('tipo', optional($inmueble)->tipo) === $tipo)>{{ $tipo }}</option>
+                        @endforeach
+                    </select>
+                    @error('tipo')
+                        <p class="text-sm text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="space-y-2">
+                    <label for="operacion" class="text-sm font-medium">Operación *</label>
+                    <select
+                        id="operacion"
+                        name="operacion"
+                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        required
+                    >
+                        <option value="">Selecciona una opción</option>
+                        @foreach ($operaciones as $operacion)
+                            <option value="{{ $operacion }}" @selected(old('operacion', optional($inmueble)->operacion) === $operacion)>{{ $operacion }}</option>
+                        @endforeach
+                    </select>
+                    @error('operacion')
+                        <p class="text-sm text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="space-y-2">
+                    <label for="estatus_id" class="text-sm font-medium">Estatus *</label>
+                    <select
+                        id="estatus_id"
+                        name="estatus_id"
+                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        required
+                    >
+                        <option value="">Selecciona un estado</option>
+                        @foreach ($statuses as $status)
+                            <option value="{{ $status->id }}" @selected((int) old('estatus_id', optional($inmueble)->estatus_id) === $status->id)>
+                                {{ $status->nombre }}
+                            </option>
+                        @endforeach
+                    </select>
+                    @error('estatus_id')
+                        <p class="text-sm text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+            </div>
+
+            <div class="space-y-2">
+                <label for="descripcion" class="text-sm font-medium">Descripción</label>
+                <textarea
+                    id="descripcion"
+                    name="descripcion"
+                    rows="5"
+                    class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    placeholder="Cuenta la historia del inmueble, puntos fuertes y contexto del vecindario"
+                >{{ old('descripcion', optional($inmueble)->descripcion) }}</textarea>
+                @error('descripcion')
+                    <p class="text-sm text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+        </div>
+    </section>
+
+    <section class="rounded-3xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/30">
+        <div class="space-y-6">
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <h2 class="text-lg font-semibold">Características</h2>
+                    <p class="text-sm text-gray-400">Detalle los elementos que ayudan a tomar decisiones rápidas.</p>
+                </div>
+                <label class="inline-flex items-center gap-2 text-sm font-medium">
+                    <input type="checkbox" name="destacado" value="1" @checked(old('destacado', optional($inmueble)->destacado)) class="h-4 w-4 rounded border-gray-600 bg-gray-800 text-indigo-500 focus:ring-indigo-400">
+                    Destacar inmueble en listados
+                </label>
+            </div>
+
+            <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                @php
+                    $featureFields = [
+                        ['id' => 'habitaciones', 'label' => 'Habitaciones'],
+                        ['id' => 'banos', 'label' => 'Baños'],
+                        ['id' => 'estacionamientos', 'label' => 'Estacionamientos'],
+                        ['id' => 'metros_cuadrados', 'label' => 'Metros cuadrados (m²)', 'step' => '0.01'],
+                        ['id' => 'superficie_construida', 'label' => 'Superficie construida (m²)', 'step' => '0.01'],
+                        ['id' => 'superficie_terreno', 'label' => 'Superficie terreno (m²)', 'step' => '0.01'],
+                        ['id' => 'anio_construccion', 'label' => 'Año de construcción'],
+                    ];
+                @endphp
+
+                @foreach ($featureFields as $field)
+                    <div class="space-y-2">
+                        <label for="{{ $field['id'] }}" class="text-sm font-medium">{{ $field['label'] }}</label>
+                        <input
+                            type="number"
+                            @if (isset($field['step'])) step="{{ $field['step'] }}" @endif
+                            min="0"
+                            id="{{ $field['id'] }}"
+                            name="{{ $field['id'] }}"
+                            value="{{ old($field['id'], optional($inmueble)->{$field['id']}) }}"
+                            class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        >
+                        @error($field['id'])
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+                @endforeach
+            </div>
+
+            <div class="grid gap-5 lg:grid-cols-2">
+                <div class="space-y-2">
+                    <label for="video_url" class="text-sm font-medium">Video del inmueble</label>
+                    <input
+                        type="url"
+                        id="video_url"
+                        name="video_url"
+                        value="{{ old('video_url', optional($inmueble)->video_url) }}"
+                        placeholder="https://www.youtube.com/..."
+                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    >
+                    @error('video_url')
+                        <p class="text-sm text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="space-y-2">
+                    <label for="tour_virtual_url" class="text-sm font-medium">Tour virtual</label>
+                    <input
+                        type="url"
+                        id="tour_virtual_url"
+                        name="tour_virtual_url"
+                        value="{{ old('tour_virtual_url', optional($inmueble)->tour_virtual_url) }}"
+                        placeholder="https://my.matterport.com/..."
+                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    >
+                    @error('tour_virtual_url')
+                        <p class="text-sm text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="rounded-3xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/30">
+        <div class="grid gap-6 lg:grid-cols-2">
+            <div class="space-y-2">
+                <label for="amenidades" class="text-sm font-medium">Amenidades destacadas</label>
+                <textarea
+                    id="amenidades"
+                    name="amenidades"
+                    rows="6"
+                    placeholder="Escribe cada amenidad en una línea. Ej. Alberca\nRoof garden\nSeguridad 24/7"
+                    class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                >{{ $amenidadesText }}</textarea>
+                @error('amenidades')
+                    <p class="text-sm text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <div class="space-y-2">
+                <label for="extras" class="text-sm font-medium">Extras o notas internas</label>
+                <textarea
+                    id="extras"
+                    name="extras"
+                    rows="6"
+                    placeholder="Ideal para registrar detalles logísticos o recordatorios para el equipo"
+                    class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                >{{ $extrasText }}</textarea>
+                @error('extras')
+                    <p class="text-sm text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+        </div>
+    </section>
+
+    <section class="rounded-3xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/30">
+        <div class="space-y-4">
+            <div>
+                <h2 class="text-lg font-semibold">Galería</h2>
+                <p class="text-sm text-gray-400">Sube hasta 10 fotografías en formato JPG o PNG. Las primeras se mostrarán como portada.</p>
+            </div>
+
+            <div class="space-y-3">
+                <input
+                    type="file"
+                    id="imagenes"
+                    name="imagenes[]"
+                    accept="image/*"
+                    multiple
+                    class="block w-full rounded-2xl border border-dashed border-gray-700 bg-gray-850/70 px-4 py-5 text-sm text-gray-300 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                >
+                @error('imagenes')
+                    <p class="text-sm text-red-400">{{ $message }}</p>
+                @enderror
+                @error('imagenes.*')
+                    <p class="text-sm text-red-400">{{ $message }}</p>
+                @enderror
+            </div>
+
+            @if ($inmueble && $inmueble->images->isNotEmpty())
+                <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    @foreach ($inmueble->images as $imagen)
+                        <label class="group relative block overflow-hidden rounded-2xl border border-gray-800 bg-gray-900/80 shadow-lg shadow-black/30">
+                            <input type="checkbox" name="imagenes_eliminar[]" value="{{ $imagen->id }}" class="absolute right-3 top-3 h-4 w-4 rounded border-gray-600 bg-gray-800 text-red-500 focus:ring-red-400">
+                            <img src="{{ $imagen->url }}" alt="Imagen inmueble" class="h-48 w-full object-cover transition duration-300 group-hover:scale-105">
+                            <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-3 text-sm text-gray-200">
+                                Marcar para eliminar
+                            </div>
+                        </label>
+                    @endforeach
+                </div>
+            @endif
+        </div>
+    </section>
+</div>

--- a/resources/views/components/layouts/admin.blade.php
+++ b/resources/views/components/layouts/admin.blade.php
@@ -17,14 +17,32 @@
             </div>
 
             <nav class="flex-1 p-4 space-y-2">
-                <a href="{{ route('dashboard') }}" class="block px-3 py-2 rounded hover:bg-gray-800">📊 Dashboard</a>
-                <a href="{{ route('contactos.index') }}" class="block px-3 py-2 rounded hover:bg-gray-800">🧑‍💼 Contactos</a>
-                {{-- <a href="{{ route('inmuebles.index') }}" class="block px-3 py-2 rounded hover:bg-gray-800">🏠 Inmuebles</a>
-                <a href="{{ route('arrendadores.index') }}" class="block px-3 py-2 rounded hover:bg-gray-800">👤 Arrendadores</a>
-                
-                <a href="{{ route('polizas.index') }}" class="block px-3 py-2 rounded hover:bg-gray-800">📑 Pólizas</a>
-                <a href="{{ route('blog.index') }}" class="block px-3 py-2 rounded hover:bg-gray-800">📝 Blog</a>
-                <a href="{{ route('finanzas.index') }}" class="block px-3 py-2 rounded hover:bg-gray-800">💰 Finanzas</a> --}}
+                @php
+                    $navLink = fn (string $route, string $label, string $pattern) => [
+                        'url' => route($route),
+                        'label' => $label,
+                        'active' => request()->routeIs($pattern),
+                    ];
+
+                    $links = [
+                        $navLink('dashboard', '📊 Dashboard', 'dashboard'),
+                        $navLink('contactos.index', '🧑‍💼 Contactos', 'contactos.*'),
+                        $navLink('inmuebles.index', '🏠 Inmuebles', 'inmuebles.*'),
+                    ];
+                @endphp
+
+                @foreach ($links as $link)
+                    <a
+                        href="{{ $link['url'] }}"
+                        @class([
+                            'block rounded-xl px-3 py-2 transition',
+                            'bg-gray-800 text-white shadow-lg shadow-indigo-500/10' => $link['active'],
+                            'hover:bg-gray-800/80 text-gray-300' => ! $link['active'],
+                        ])
+                    >
+                        {{ $link['label'] }}
+                    </a>
+                @endforeach
             </nav>
 
             <!-- Usuario / Logout -->

--- a/resources/views/inmuebles/create.blade.php
+++ b/resources/views/inmuebles/create.blade.php
@@ -1,0 +1,27 @@
+<x-layouts.admin title="Nuevo inmueble">
+    <div class="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8">
+        <div class="rounded-3xl border border-gray-800 bg-gradient-to-br from-gray-900 via-gray-900 to-gray-950 p-8 text-white shadow-2xl shadow-black/30">
+            <p class="text-sm uppercase tracking-[0.3em] text-indigo-300">Catálogo</p>
+            <h1 class="mt-2 text-3xl font-semibold md:text-4xl">Registrar nuevo inmueble</h1>
+            <p class="mt-3 max-w-2xl text-sm text-gray-300 md:text-base">
+                Completa la información clave para compartirlo con tus prospectos. Puedes actualizar las fotos y detalles en cualquier momento.
+            </p>
+        </div>
+
+        <form action="{{ route('inmuebles.store') }}" method="POST" enctype="multipart/form-data" class="space-y-8">
+            @csrf
+
+            <x-inmuebles.form :statuses="$statuses" :tipos="$tipos" :operaciones="$operaciones" />
+
+            <div class="flex flex-col items-stretch gap-3 border-t border-gray-800 pt-6 sm:flex-row sm:justify-between">
+                <p class="text-sm text-gray-400">Al guardar, el inmueble se marcará como asignado a tu usuario.</p>
+                <div class="flex gap-3">
+                    <a href="{{ route('inmuebles.index') }}" class="inline-flex items-center justify-center rounded-2xl border border-gray-700 px-5 py-3 text-sm font-medium text-gray-300 transition hover:border-gray-500 hover:text-white">Cancelar</a>
+                    <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-2xl bg-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400">
+                        Guardar inmueble
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</x-layouts.admin>

--- a/resources/views/inmuebles/edit.blade.php
+++ b/resources/views/inmuebles/edit.blade.php
@@ -1,0 +1,56 @@
+<x-layouts.admin :title="'Editar inmueble · ' . $inmueble->titulo">
+    <div class="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8">
+        <div class="rounded-3xl border border-gray-800 bg-gradient-to-br from-gray-900 via-gray-900 to-gray-950 p-8 text-white shadow-2xl shadow-black/30">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                    <p class="text-sm uppercase tracking-[0.3em] text-indigo-300">Gestión</p>
+                    <h1 class="mt-2 text-3xl font-semibold md:text-4xl">{{ $inmueble->titulo }}</h1>
+                    <div class="mt-3 flex flex-wrap items-center gap-3 text-sm text-gray-300">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-indigo-500/10 px-3 py-1 text-indigo-200">
+                            {{ $inmueble->operacion }} · {{ $inmueble->tipo }}
+                        </span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-gray-950/70 px-3 py-1 text-gray-200">
+                            Estatus: <span class="font-semibold" style="color: {{ $inmueble->status->color }}">{{ $inmueble->status->nombre }}</span>
+                        </span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-gray-950/70 px-3 py-1 text-gray-200">
+                            Actualizado {{ $inmueble->lastUpdatedDiff() ?? 'recién' }}
+                        </span>
+                    </div>
+                </div>
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+                    <a href="{{ route('inmuebles.index') }}" class="inline-flex items-center justify-center rounded-2xl border border-gray-700 px-5 py-3 text-sm font-medium text-gray-300 transition hover:border-gray-500 hover:text-white">Volver al listado</a>
+                    <form action="{{ route('inmuebles.destroy', $inmueble) }}" method="POST" data-swal-confirm data-swal-title="¿Eliminar inmueble?" data-swal-confirm="Se eliminarán también sus fotografías." data-swal-confirm-button="Sí, eliminar" data-swal-cancel-button="Cancelar">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-2xl border border-red-500/40 bg-red-500/10 px-5 py-3 text-sm font-semibold text-red-200 transition hover:bg-red-500/20">
+                            Eliminar inmueble
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        @if (session('status'))
+            <div class="rounded-3xl border border-emerald-500/40 bg-emerald-500/10 px-6 py-4 text-sm text-emerald-100 shadow-lg shadow-emerald-500/10">
+                {{ session('status') }}
+            </div>
+        @endif
+
+        <form action="{{ route('inmuebles.update', $inmueble) }}" method="POST" enctype="multipart/form-data" class="space-y-8">
+            @csrf
+            @method('PUT')
+
+            <x-inmuebles.form :inmueble="$inmueble" :statuses="$statuses" :tipos="$tipos" :operaciones="$operaciones" />
+
+            <div class="flex flex-col items-stretch gap-3 border-t border-gray-800 pt-6 sm:flex-row sm:justify-between">
+                <p class="text-sm text-gray-400">Los cambios se guardan en tu historial para futuras referencias.</p>
+                <div class="flex gap-3">
+                    <a href="{{ route('inmuebles.index') }}" class="inline-flex items-center justify-center rounded-2xl border border-gray-700 px-5 py-3 text-sm font-medium text-gray-300 transition hover:border-gray-500 hover:text-white">Cancelar</a>
+                    <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-2xl bg-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400">
+                        Guardar cambios
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</x-layouts.admin>

--- a/resources/views/inmuebles/index.blade.php
+++ b/resources/views/inmuebles/index.blade.php
@@ -1,0 +1,175 @@
+<x-layouts.admin title="Inmuebles">
+    <div class="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-10">
+        <div class="rounded-3xl border border-gray-800 bg-gradient-to-br from-gray-900 via-gray-900 to-gray-950 p-8 text-white shadow-2xl shadow-black/30">
+            <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                <div>
+                    <p class="text-sm uppercase tracking-[0.3em] text-indigo-300">Portafolio</p>
+                    <h1 class="mt-2 text-3xl font-semibold md:text-4xl">Inmuebles disponibles</h1>
+                    <p class="mt-3 max-w-3xl text-sm text-gray-200 md:text-base">
+                        Administra tu inventario con filtros inteligentes y una vista pensada para móviles. Mantén el catálogo siempre listo para compartir con tus prospectos.
+                    </p>
+                </div>
+                <a href="{{ route('inmuebles.create') }}" class="inline-flex items-center justify-center gap-2 rounded-2xl bg-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400">
+                    Nuevo inmueble
+                </a>
+            </div>
+        </div>
+
+        @if (session('status'))
+            <div class="rounded-3xl border border-emerald-500/40 bg-emerald-500/10 px-6 py-4 text-sm text-emerald-100 shadow-lg shadow-emerald-500/10">
+                {{ session('status') }}
+            </div>
+        @endif
+
+        <div class="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+            <div class="rounded-3xl border border-gray-800 bg-gray-900/70 p-6 shadow-lg shadow-black/20">
+                <p class="text-xs uppercase tracking-widest text-gray-500">Total inmuebles</p>
+                <p class="mt-2 text-3xl font-semibold text-white">{{ $metrics['total'] }}</p>
+            </div>
+            <div class="rounded-3xl border border-gray-800 bg-gray-900/70 p-6 shadow-lg shadow-indigo-900/20">
+                <p class="text-xs uppercase tracking-widest text-indigo-300">Destacados</p>
+                <p class="mt-2 text-3xl font-semibold text-indigo-200">{{ $metrics['destacados'] }}</p>
+            </div>
+            @foreach ($operationBreakdown as $operation => $count)
+                <div class="rounded-3xl border border-gray-800 bg-gray-900/70 p-6 shadow-lg shadow-black/20">
+                    <p class="text-xs uppercase tracking-widest text-gray-500">{{ $operation }}</p>
+                    <p class="mt-2 text-3xl font-semibold text-white">{{ $count }}</p>
+                </div>
+            @endforeach
+            @if ($operationBreakdown->isEmpty())
+                <div class="rounded-3xl border border-gray-800 bg-gray-900/70 p-6 shadow-lg shadow-black/20">
+                    <p class="text-xs uppercase tracking-widest text-gray-500">Operaciones</p>
+                    <p class="mt-2 text-3xl font-semibold text-white">0</p>
+                </div>
+            @endif
+        </div>
+
+        <form action="{{ route('inmuebles.index') }}" method="GET" class="rounded-3xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/20">
+            <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <div class="space-y-2">
+                    <label for="search" class="text-sm font-medium text-gray-300">Buscar por título o dirección</label>
+                    <input
+                        type="search"
+                        id="search"
+                        name="search"
+                        value="{{ $search }}"
+                        placeholder="Ej. Penthouse en Polanco"
+                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    >
+                </div>
+                <div class="space-y-2">
+                    <label for="operacion" class="text-sm font-medium text-gray-300">Operación</label>
+                    <select
+                        id="operacion"
+                        name="operacion"
+                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    >
+                        <option value="">Todas</option>
+                        @foreach (\App\Models\Inmueble::OPERACIONES as $operacion)
+                            <option value="{{ $operacion }}" @selected($selectedOperacion === $operacion)>{{ $operacion }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="space-y-2">
+                    <label for="estatus" class="text-sm font-medium text-gray-300">Estatus</label>
+                    <select
+                        id="estatus"
+                        name="estatus"
+                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    >
+                        <option value="">Todos</option>
+                        @foreach ($statuses as $status)
+                            <option value="{{ $status->id }}" @selected((string) $selectedStatus === (string) $status->id)>
+                                {{ $status->nombre }} ({{ $status->inmuebles_count }})
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="flex items-end gap-3">
+                    <button type="submit" class="w-full rounded-2xl bg-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400">
+                        Aplicar filtros
+                    </button>
+                    <a href="{{ route('inmuebles.index') }}" class="hidden rounded-2xl border border-gray-700 px-6 py-3 text-sm font-medium text-gray-300 transition hover:border-gray-500 hover:text-white md:inline-flex md:items-center md:justify-center">Limpiar</a>
+                </div>
+            </div>
+        </form>
+
+        @if ($inmuebles->isEmpty())
+            <div class="rounded-3xl border border-gray-800 bg-gray-900/70 p-10 text-center shadow-xl shadow-black/30">
+                <p class="text-lg font-semibold text-gray-200">Aún no has registrado inmuebles.</p>
+                <p class="mt-2 text-sm text-gray-400">Comienza creando tu primer inmueble para compartirlo con clientes.</p>
+                <a href="{{ route('inmuebles.create') }}" class="mt-6 inline-flex items-center justify-center gap-2 rounded-2xl bg-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400">
+                    Crear inmueble
+                </a>
+            </div>
+        @else
+            <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+                @foreach ($inmuebles as $inmueble)
+                    <article class="flex flex-col overflow-hidden rounded-3xl border border-gray-800 bg-gray-900/70 shadow-xl shadow-black/30 transition hover:-translate-y-1 hover:border-indigo-500/60">
+                        <div class="relative h-56 w-full overflow-hidden">
+                            @if ($inmueble->coverImage)
+                                <img src="{{ $inmueble->coverImage->url }}" alt="{{ $inmueble->titulo }}" class="h-full w-full object-cover transition duration-500 group-hover:scale-105">
+                            @else
+                                <div class="flex h-full w-full items-center justify-center bg-gradient-to-br from-gray-800 to-gray-900 text-gray-500">
+                                    <span class="text-4xl">🏠</span>
+                                </div>
+                            @endif
+                            @if ($inmueble->destacado)
+                                <span class="absolute left-4 top-4 inline-flex items-center gap-2 rounded-full bg-amber-500/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-gray-900">Destacado</span>
+                            @endif
+                        </div>
+
+                        <div class="flex flex-1 flex-col gap-5 p-6">
+                            <div class="space-y-2">
+                                <div class="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-gray-400">
+                                    <span class="rounded-full bg-gray-800/80 px-3 py-1">{{ $inmueble->operacion }}</span>
+                                    <span class="rounded-full bg-gray-800/80 px-3 py-1">{{ $inmueble->tipo }}</span>
+                                </div>
+                                <h2 class="text-xl font-semibold text-white">{{ $inmueble->titulo }}</h2>
+                                <p class="text-sm text-gray-400">{{ $inmueble->direccion }}{{ $inmueble->ciudad ? ', ' . $inmueble->ciudad : '' }}</p>
+                            </div>
+
+                            <div class="flex flex-wrap items-center gap-3 text-sm text-gray-300">
+                                <span class="text-lg font-semibold text-indigo-300">{{ $inmueble->formattedPrice() }}</span>
+                                @if ($inmueble->habitaciones)
+                                    <span>🛏 {{ $inmueble->habitaciones }}</span>
+                                @endif
+                                @if ($inmueble->banos)
+                                    <span>🛁 {{ $inmueble->banos }}</span>
+                                @endif
+                                @if ($inmueble->estacionamientos)
+                                    <span>🚗 {{ $inmueble->estacionamientos }}</span>
+                                @endif
+                                @if ($inmueble->metros_cuadrados)
+                                    <span>📐 {{ $inmueble->metros_cuadrados }} m²</span>
+                                @endif
+                            </div>
+
+                            @if (filled($inmueble->amenidades))
+                                <ul class="flex flex-wrap gap-2 text-xs text-gray-400">
+                                    @foreach (collect($inmueble->amenidades)->take(4) as $amenidad)
+                                        <li class="rounded-full bg-gray-850/80 px-3 py-1">{{ $amenidad }}</li>
+                                    @endforeach
+                                </ul>
+                            @endif
+
+                            <div class="mt-auto flex items-center justify-between">
+                                <span class="inline-flex items-center gap-2 rounded-full bg-gray-800/80 px-3 py-1 text-xs font-medium text-gray-200">
+                                    <span class="inline-block h-2 w-2 rounded-full" style="background-color: {{ $inmueble->status->color }}"></span>
+                                    {{ $inmueble->status->nombre }}
+                                </span>
+                                <a href="{{ route('inmuebles.edit', $inmueble) }}" class="inline-flex items-center gap-2 rounded-2xl border border-indigo-500/60 px-4 py-2 text-sm font-medium text-indigo-200 transition hover:bg-indigo-500/10">
+                                    Gestionar
+                                </a>
+                            </div>
+                        </div>
+                    </article>
+                @endforeach
+            </div>
+
+            <div class="pt-6">
+                {{ $inmuebles->withQueryString()->links() }}
+            </div>
+        @endif
+    </div>
+</x-layouts.admin>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ContactController;
+use App\Http\Controllers\InmuebleController;
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
 use Livewire\Volt\Volt;
@@ -14,15 +15,6 @@ Route::get('/dashboard', function () {
 })->middleware(['auth'])->name('dashboard');
 
 Route::redirect('/', '/dashboard')->name('home');
-
-// Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
-// Route::resource('inmuebles', InmuebleController::class);
-// Route::resource('arrendadores', ArrendadorController::class);
-// Route::resource('inquilinos', InquilinoController::class);
-// Route::resource('polizas', PolizaController::class);
-// Route::resource('blog', BlogController::class);
-// Route::get('/finanzas', [FinanzaController::class, 'index'])->name('finanzas.index');
-
 
 Route::middleware(['auth'])->group(function () {
     Route::redirect('settings', 'settings/profile');
@@ -56,6 +48,8 @@ Route::middleware(['auth'])->group(function () {
         ->name('contactos.comentarios.store');
     Route::post('/contactos/{contact}/intereses', [ContactController::class, 'storeInterest'])
         ->name('contactos.intereses.store');
+
+    Route::resource('inmuebles', InmuebleController::class)->except(['show']);
 });
 
 require __DIR__ . '/auth.php';

--- a/tests/Feature/InmuebleManagementTest.php
+++ b/tests/Feature/InmuebleManagementTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Inmueble;
+use App\Models\InmuebleImage;
+use App\Models\InmuebleStatus;
+use App\Models\User;
+use Database\Seeders\InmuebleStatusSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class InmuebleManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'filesystems.default' => 's3',
+            'filesystems.disks.s3.bucket' => 'testing-bucket',
+        ]);
+    }
+
+    public function test_user_can_create_inmueble_with_images(): void
+    {
+        Storage::fake('s3');
+        $this->seed(InmuebleStatusSeeder::class);
+
+        $user = User::factory()->create();
+        $status = InmuebleStatus::first();
+
+        $response = $this->actingAs($user)->post(route('inmuebles.store'), [
+            'titulo' => 'Casa en la playa',
+            'precio' => '12000000',
+            'direccion' => 'Av. del Sol 123',
+            'ciudad' => 'Cancún',
+            'estado' => 'Quintana Roo',
+            'codigo_postal' => '77500',
+            'tipo' => 'Casa',
+            'operacion' => 'Venta',
+            'estatus_id' => $status->id,
+            'habitaciones' => 3,
+            'banos' => 2,
+            'estacionamientos' => 1,
+            'amenidades' => "Alberca\nRoof Garden",
+            'imagenes' => [
+                UploadedFile::fake()->image('foto1.jpg', 1200, 800),
+                UploadedFile::fake()->image('foto2.jpg', 1200, 800),
+            ],
+        ]);
+
+        $response->assertRedirect(route('inmuebles.index'));
+
+        $this->assertDatabaseHas('inmuebles', [
+            'titulo' => 'Casa en la playa',
+            'asesor_id' => $user->id,
+            'operacion' => 'Venta',
+        ]);
+
+        $image = InmuebleImage::first();
+        $this->assertNotNull($image);
+        Storage::disk('s3')->assertExists($image->path);
+    }
+
+    public function test_user_can_update_inmueble_and_replace_images(): void
+    {
+        Storage::fake('s3');
+        $this->seed(InmuebleStatusSeeder::class);
+
+        $user = User::factory()->create();
+        $status = InmuebleStatus::first();
+
+        $inmueble = Inmueble::create([
+            'asesor_id' => $user->id,
+            'titulo' => 'Departamento céntrico',
+            'precio' => 8500000,
+            'direccion' => 'Av. Reforma 101',
+            'ciudad' => 'CDMX',
+            'estado' => 'Ciudad de México',
+            'codigo_postal' => '06500',
+            'tipo' => 'Departamento',
+            'operacion' => 'Venta',
+            'estatus_id' => $status->id,
+        ]);
+
+        $existingPath = "inmuebles/{$inmueble->id}/original.jpg";
+        Storage::disk('s3')->put($existingPath, 'fake content');
+
+        $image = $inmueble->images()->create([
+            'disk' => 's3',
+            'path' => $existingPath,
+            'url' => Storage::disk('s3')->url($existingPath),
+            'orden' => 1,
+        ]);
+
+        $response = $this->actingAs($user)->put(route('inmuebles.update', $inmueble), [
+            'titulo' => 'Departamento remodelado',
+            'precio' => '9500000',
+            'direccion' => 'Av. Reforma 101',
+            'ciudad' => 'CDMX',
+            'estado' => 'Ciudad de México',
+            'codigo_postal' => '06500',
+            'tipo' => 'Departamento',
+            'operacion' => 'Venta',
+            'estatus_id' => $status->id,
+            'habitaciones' => 2,
+            'banos' => 2,
+            'imagenes_eliminar' => [$image->id],
+            'imagenes' => [
+                UploadedFile::fake()->image('nueva.jpg', 1200, 800),
+            ],
+        ]);
+
+        $response->assertRedirect(route('inmuebles.edit', $inmueble));
+
+        $inmueble->refresh();
+
+        $this->assertSame('Departamento remodelado', $inmueble->titulo);
+        Storage::disk('s3')->assertMissing($existingPath);
+        $this->assertCount(1, $inmueble->images);
+    }
+
+    public function test_user_can_delete_inmueble_and_images(): void
+    {
+        Storage::fake('s3');
+        $this->seed(InmuebleStatusSeeder::class);
+
+        $user = User::factory()->create();
+        $status = InmuebleStatus::first();
+
+        $inmueble = Inmueble::create([
+            'asesor_id' => $user->id,
+            'titulo' => 'Loft minimalista',
+            'precio' => 4500000,
+            'direccion' => 'Calle Arte 55',
+            'ciudad' => 'Guadalajara',
+            'estado' => 'Jalisco',
+            'codigo_postal' => '44100',
+            'tipo' => 'Departamento',
+            'operacion' => 'Renta',
+            'estatus_id' => $status->id,
+        ]);
+
+        $existingPath = "inmuebles/{$inmueble->id}/loft.jpg";
+        Storage::disk('s3')->put($existingPath, 'fake content');
+
+        $inmueble->images()->create([
+            'disk' => 's3',
+            'path' => $existingPath,
+            'url' => Storage::disk('s3')->url($existingPath),
+            'orden' => 1,
+        ]);
+
+        $response = $this->actingAs($user)->delete(route('inmuebles.destroy', $inmueble));
+
+        $response->assertRedirect(route('inmuebles.index'));
+
+        $this->assertDatabaseMissing('inmuebles', ['id' => $inmueble->id]);
+        Storage::disk('s3')->assertMissing($existingPath);
+    }
+}


### PR DESCRIPTION
## Summary
- add database structure, models, and seeders for inmuebles, their statuses, and associated images stored on S3
- implement controller, form requests, and Blade views that deliver a mobile-first inmueble catalog with search, filters, and management actions
- provide feature coverage for creating, updating, and deleting inmuebles, including S3 image handling and cleanup

## Testing
- `composer install` *(fails: GitHub API requires authentication for package downloads)*


------
https://chatgpt.com/codex/tasks/task_e_68d4f6ee1ca883239598fa095a4befca