### PR TITLE
Fix select background styling on properties view

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -74,3 +74,13 @@ select:focus[data-flux-control] {
     background-color: #111827;
     color: #f9fafb;
 }
+
+select.bg-gray-850\/70 {
+    background-color: rgba(17, 24, 39, 0.7);
+    color: #f9fafb;
+}
+
+select.bg-gray-850\/70 option {
+    background-color: #111827;
+    color: #f9fafb;
+}


### PR DESCRIPTION
## Summary
- ensure selects using the bg-gray-850/70 utility render with dark backgrounds
- keep dropdown options consistent with the app's dark theme

## Testing
- npm run build *(fails: @tailwindcss/vite cannot resolve vendor/livewire/flux/dist/flux.css)*

------
https://chatgpt.com/codex/tasks/task_e_68d5472e559083239b779394fe521ccc