### PR TITLE
Add watermarked gallery previews when uploading images

### DIFF
--- a/resources/views/components/inmuebles/form.blade.php
+++ b/resources/views/components/inmuebles/form.blade.php
@@ -315,6 +315,7 @@
                     name="imagenes[]"
                     accept="image/*"
                     multiple
+                    data-gallery-input
                     class="block w-full rounded-2xl border border-dashed border-gray-700 bg-gray-850/70 px-4 py-5 text-sm text-gray-300 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
                 >
                 @error('imagenes')
@@ -323,6 +324,25 @@
                 @error('imagenes.*')
                     <p class="text-sm text-red-400">{{ $message }}</p>
                 @enderror
+            </div>
+
+            <div
+                class="hidden grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
+                data-gallery-previews-container
+            >
+                <template data-gallery-preview-template>
+                    <div class="group relative overflow-hidden rounded-2xl border border-gray-800 bg-gray-900/60 shadow-lg shadow-black/30 transition">
+                        <div class="flex h-48 items-center justify-center bg-gray-850/80 text-sm text-gray-400" data-gallery-loading>
+                            Procesando vista previa...
+                        </div>
+                        <img
+                            data-gallery-preview-image
+                            alt="Vista previa de la imagen"
+                            class="hidden h-48 w-full object-cover transition duration-300 group-hover:scale-105"
+                        >
+                        <p class="hidden px-3 pb-3 text-xs text-gray-400" data-gallery-error></p>
+                    </div>
+                </template>
             </div>
 
             @if ($inmueble && $inmueble->images->isNotEmpty())


### PR DESCRIPTION
## Summary
- add a gallery preview container to the create/edit inmueble form that will display the generated watermarked images
- implement client-side logic that processes selected images, composites the watermark, and renders the previews dynamically
- handle loading and error states during the preview generation flow while ensuring the watermark image is cached for reuse

## Testing
- npm run build *(fails: Can't resolve '../../vendor/livewire/flux/dist/flux.css' in '/workspace/inmobiliaria-backend/resources/css')*

------
https://chatgpt.com/codex/tasks/task_e_68d55b94bff08323a53e1b629ac1c73f