### PR TITLE
Use presigned watermark preview

### DIFF
--- a/config/inmuebles.php
+++ b/config/inmuebles.php
@@ -16,6 +16,9 @@ return [
             'position' => env('INMUEBLES_WATERMARK_POSITION', 'bottom-right'),
             'offset_x' => (int) env('INMUEBLES_WATERMARK_OFFSET_X', 24),
             'offset_y' => (int) env('INMUEBLES_WATERMARK_OFFSET_Y', 24),
+            'preview_disk' => env('INMUEBLES_WATERMARK_PREVIEW_DISK', 's3'),
+            'preview_path' => env('INMUEBLES_WATERMARK_PREVIEW_PATH', ''),
+            'preview_ttl' => (int) env('INMUEBLES_WATERMARK_PREVIEW_TTL', 10),
         ],
     ],
 ];

--- a/resources/views/components/inmuebles/form.blade.php
+++ b/resources/views/components/inmuebles/form.blade.php
@@ -3,6 +3,7 @@
     'statuses' => collect(),
     'tipos' => [],
     'operaciones' => [],
+    'watermarkPreviewUrl' => null,
 ])
 
 @php
@@ -329,6 +330,9 @@
             <div
                 class="hidden grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
                 data-gallery-previews-container
+                @if ($watermarkPreviewUrl)
+                    data-gallery-watermark-url="{{ $watermarkPreviewUrl }}"
+                @endif
             >
                 <template data-gallery-preview-template>
                     <div class="group relative overflow-hidden rounded-2xl border border-gray-800 bg-gray-900/60 shadow-lg shadow-black/30 transition">

--- a/resources/views/inmuebles/create.blade.php
+++ b/resources/views/inmuebles/create.blade.php
@@ -11,7 +11,12 @@
         <form action="{{ route('inmuebles.store') }}" method="POST" enctype="multipart/form-data" class="space-y-8">
             @csrf
 
-            <x-inmuebles.form :statuses="$statuses" :tipos="$tipos" :operaciones="$operaciones" />
+            <x-inmuebles.form
+                :statuses="$statuses"
+                :tipos="$tipos"
+                :operaciones="$operaciones"
+                :watermark-preview-url="$watermarkPreviewUrl"
+            />
 
             <div class="flex flex-col items-stretch gap-3 border-t border-gray-800 pt-6 sm:flex-row sm:justify-between">
                 <p class="text-sm text-gray-400">Al guardar, el inmueble se marcará como asignado a tu usuario.</p>

--- a/resources/views/inmuebles/edit.blade.php
+++ b/resources/views/inmuebles/edit.blade.php
@@ -40,7 +40,13 @@
             @csrf
             @method('PUT')
 
-            <x-inmuebles.form :inmueble="$inmueble" :statuses="$statuses" :tipos="$tipos" :operaciones="$operaciones" />
+            <x-inmuebles.form
+                :inmueble="$inmueble"
+                :statuses="$statuses"
+                :tipos="$tipos"
+                :operaciones="$operaciones"
+                :watermark-preview-url="$watermarkPreviewUrl"
+            />
 
             <div class="flex flex-col items-stretch gap-3 border-t border-gray-800 pt-6 sm:flex-row sm:justify-between">
                 <p class="text-sm text-gray-400">Los cambios se guardan en tu historial para futuras referencias.</p>


### PR DESCRIPTION
## Summary
- genera URL temporal de la marca de agua desde S3 y la comparte con los formularios de inmuebles
- expone la URL al componente de galería para que las vistas previas puedan cargarla sin errores CORS
- ajusta el procesamiento en el frontend para cubrir toda la imagen con la marca de agua semitransparente y añade opciones de configuración para el preview

## Testing
- `npm run build` *(falla: falta `vendor/livewire/flux/dist/flux.css` en esta instalación)*
- `php artisan test` *(falla: el proyecto no tiene dependencias de Composer instaladas en este entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68d5697c3a5083239698f91639d38f12