### PR TITLE
Use local watermark asset

### DIFF
--- a/config/inmuebles.php
+++ b/config/inmuebles.php
@@ -12,13 +12,10 @@ return [
             'height' => (int) env('INMUEBLES_THUMB_HEIGHT', 200),
         ],
         'watermark' => [
-            'path' => env('INMUEBLES_WATERMARK_PATH', resource_path('images/watermark.png')),
+            'path' => env('INMUEBLES_WATERMARK_PATH', resource_path('images/MarcaDeAgua_GDE.png')),
             'position' => env('INMUEBLES_WATERMARK_POSITION', 'bottom-right'),
             'offset_x' => (int) env('INMUEBLES_WATERMARK_OFFSET_X', 24),
             'offset_y' => (int) env('INMUEBLES_WATERMARK_OFFSET_Y', 24),
-            'preview_disk' => env('INMUEBLES_WATERMARK_PREVIEW_DISK', 's3'),
-            'preview_path' => env('INMUEBLES_WATERMARK_PREVIEW_PATH', ''),
-            'preview_ttl' => (int) env('INMUEBLES_WATERMARK_PREVIEW_TTL', 10),
         ],
     ],
 ];


### PR DESCRIPTION
## Summary
- point the watermark configuration to the local `resources/images/MarcaDeAgua_GDE.png` asset
- simplify the watermark preview helper to return a base64 data URI from the local image
- load the watermark binary for Intervention Image directly from the local resources path

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d574585f148323856eb0cbe2b52d16