### PR TITLE
Use local watermark asset

### DIFF
--- a/app/Http/Controllers/InmuebleController.php
+++ b/app/Http/Controllers/InmuebleController.php
@@ -212,6 +212,24 @@ class InmuebleController extends Controller
 
     private function getWatermarkPreviewUrl(): ?string
     {
+        $localWatermarkPath = config('inmuebles.images.watermark.path');
+
+        if ($localWatermarkPath && file_exists($localWatermarkPath)) {
+            try {
+                $contents = file_get_contents($localWatermarkPath);
+
+                if ($contents === false) {
+                    return null;
+                }
+
+                $mimeType = mime_content_type($localWatermarkPath) ?: 'image/png';
+
+                return sprintf('data:%s;base64,%s', $mimeType, base64_encode($contents));
+            } catch (Throwable $exception) {
+                report($exception);
+            }
+        }
+
         $diskName = (string) config('inmuebles.images.watermark.preview_disk', '');
         $path = trim((string) config('inmuebles.images.watermark.preview_path', ''));
 
@@ -268,24 +286,6 @@ class InmuebleController extends Controller
                         report($diskException);
                     }
                 }
-            } catch (Throwable $exception) {
-                report($exception);
-            }
-        }
-
-        $localWatermarkPath = config('inmuebles.images.watermark.path');
-
-        if ($localWatermarkPath && file_exists($localWatermarkPath)) {
-            try {
-                $contents = file_get_contents($localWatermarkPath);
-
-                if ($contents === false) {
-                    return null;
-                }
-
-                $mimeType = mime_content_type($localWatermarkPath) ?: 'image/png';
-
-                return sprintf('data:%s;base64,%s', $mimeType, base64_encode($contents));
             } catch (Throwable $exception) {
                 report($exception);
             }

--- a/app/Services/InmuebleImageService.php
+++ b/app/Services/InmuebleImageService.php
@@ -251,6 +251,12 @@ class InmuebleImageService
             return null;
         }
 
+        if (is_file($path)) {
+            $contents = file_get_contents($path);
+
+            return $contents === false ? null : (string) $contents;
+        }
+
         $diskName = (string) config('inmuebles.images.watermark.disk', '');
 
         if ($diskName !== '') {
@@ -267,12 +273,6 @@ class InmuebleImageService
             } catch (Throwable $exception) {
                 report($exception);
             }
-        }
-
-        if (is_file($path)) {
-            $contents = file_get_contents($path);
-
-            return $contents === false ? null : (string) $contents;
         }
 
         if (filter_var($path, FILTER_VALIDATE_URL)) {

--- a/config/inmuebles.php
+++ b/config/inmuebles.php
@@ -12,7 +12,7 @@ return [
             'height' => (int) env('INMUEBLES_THUMB_HEIGHT', 200),
         ],
         'watermark' => [
-            'path' => env('INMUEBLES_WATERMARK_PATH', resource_path('images/watermark.png')),
+            'path' => env('INMUEBLES_WATERMARK_PATH', resource_path('images/MarcaDeAgua_GDE.png')),
             'disk' => env('INMUEBLES_WATERMARK_DISK'),
             'position' => env('INMUEBLES_WATERMARK_POSITION', 'bottom-right'),
             'offset_x' => (int) env('INMUEBLES_WATERMARK_OFFSET_X', 24),


### PR DESCRIPTION
## Summary
- default the watermark configuration to the bundled MarcaDeAgua_GDE.png asset
- load the local watermark image for previews before falling back to external disks
- ensure Intervention Image reads the same local watermark asset before considering remote disks

## Testing
- Not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d578f1c35883238fd4b4038f0dc469