### PR TITLE
Fix gallery preview watermark opacity

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -375,8 +375,6 @@ document.addEventListener("DOMContentLoaded", () => {
                         sourceY = (watermarkHeight - sourceHeight) / 2;
                     }
 
-                    context.save();
-                    context.globalAlpha = 0.25;
                     context.drawImage(
                         watermark,
                         sourceX,
@@ -388,7 +386,6 @@ document.addEventListener("DOMContentLoaded", () => {
                         canvasWidth,
                         canvasHeight,
                     );
-                    context.restore();
                 }
 
                 const previewUrl = canvas.toDataURL("image/jpeg", 0.92);


### PR DESCRIPTION
## Summary
- ensure the gallery preview draws the watermark with its original opacity so it is visible on top of the image

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d57dac27dc83238dd769e9e1570c67