### PR TITLE
Fix watermark generation by resolving Intervention Image driver

### DIFF
--- a/app/Services/InmuebleImageService.php
+++ b/app/Services/InmuebleImageService.php
@@ -378,9 +378,39 @@ class InmuebleImageService
                 return app($class);
             }
 
+            $driver = $this->resolveImageDriver();
+
+            if ($driver !== null) {
+                return new $class($driver);
+            }
+
             return app()->make($class);
         } catch (\Throwable $exception) {
+            report($exception);
+
             return null;
         }
+    }
+
+    protected function resolveImageDriver(): ?object
+    {
+        $drivers = [
+            '\\Intervention\\Image\\Drivers\\Imagick\\Driver',
+            '\\Intervention\\Image\\Drivers\\Gd\\Driver',
+        ];
+
+        foreach ($drivers as $driverClass) {
+            if (! class_exists($driverClass)) {
+                continue;
+            }
+
+            try {
+                return new $driverClass();
+            } catch (\Throwable $exception) {
+                report($exception);
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- ensure the image manager resolution creates an Intervention Image manager with a concrete driver
- fallback through Imagick and GD drivers so watermark processing can execute
- report driver resolution failures for easier debugging

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d5805147788323ab2f2e8260496d22