### PR TITLE
Fix watermark preview path resolution

### DIFF
--- a/app/Http/Controllers/InmuebleController.php
+++ b/app/Http/Controllers/InmuebleController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\UpdateInmuebleRequest;
 use App\Models\Inmueble;
 use App\Models\InmuebleStatus;
 use App\Services\InmuebleImageService;
+use App\Support\WatermarkPathResolver;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Database\Eloquent\Builder;
@@ -211,7 +212,7 @@ class InmuebleController extends Controller
 
     private function getWatermarkPreviewUrl(): ?string
     {
-        $localWatermarkPath = config('inmuebles.images.watermark.path');
+        $localWatermarkPath = WatermarkPathResolver::resolve(config('inmuebles.images.watermark.path'));
 
         if ($localWatermarkPath && file_exists($localWatermarkPath)) {
             try {
@@ -230,18 +231,18 @@ class InmuebleController extends Controller
         }
 
         $diskName = (string) config('inmuebles.images.watermark.preview_disk', '');
-        $path = trim((string) config('inmuebles.images.watermark.preview_path', ''));
+        $path = str_replace('\\', '/', trim((string) config('inmuebles.images.watermark.preview_path', '')));
 
         if ($diskName === '' && $path === '') {
             $diskName = (string) config('inmuebles.images.watermark.disk', '');
-            $path = trim((string) config('inmuebles.images.watermark.path', ''));
+            $path = str_replace('\\', '/', trim((string) config('inmuebles.images.watermark.path', '')));
         } else {
             if ($diskName === '') {
                 $diskName = (string) config('inmuebles.images.watermark.disk', '');
             }
 
             if ($path === '') {
-                $path = trim((string) config('inmuebles.images.watermark.path', ''));
+                $path = str_replace('\\', '/', trim((string) config('inmuebles.images.watermark.path', '')));
             }
         }
 

--- a/app/Services/InmuebleImageService.php
+++ b/app/Services/InmuebleImageService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Inmueble;
 use App\Models\InmuebleImage;
 use App\Support\AddressSlugger;
+use App\Support\WatermarkPathResolver;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
@@ -245,9 +246,9 @@ class InmuebleImageService
 
     protected function resolveWatermarkContents(): ?string
     {
-        $path = trim((string) config('inmuebles.images.watermark.path', ''));
+        $path = WatermarkPathResolver::resolve(config('inmuebles.images.watermark.path'));
 
-        if ($path === '') {
+        if ($path === null || $path === '') {
             return null;
         }
 

--- a/app/Support/WatermarkPathResolver.php
+++ b/app/Support/WatermarkPathResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Support;
+
+class WatermarkPathResolver
+{
+    public static function resolve(?string $path): ?string
+    {
+        if ($path === null) {
+            return null;
+        }
+
+        $trimmedPath = trim($path);
+
+        if ($trimmedPath === '') {
+            return null;
+        }
+
+        $normalizedPath = str_replace('\\', '/', $trimmedPath);
+
+        if (preg_match('/^(?:[a-zA-Z]:)?\//', $normalizedPath)) {
+            return $normalizedPath;
+        }
+
+        $projectPath = base_path($normalizedPath);
+
+        if (file_exists($projectPath)) {
+            return $projectPath;
+        }
+
+        return $normalizedPath;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a shared watermark path resolver to normalize local watermark locations
- ensure the preview URL builder and image service use normalized paths to load the watermark regardless of path separators

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d5941faa5483238d8fd413f19f5673