### PR TITLE
Fix default disk for property images

### DIFF
--- a/app/Http/Controllers/InmuebleController.php
+++ b/app/Http/Controllers/InmuebleController.php
@@ -339,7 +339,9 @@ class InmuebleController extends Controller
      */
     protected function resolveImageDisk(): string
     {
-        if (config('filesystems.default') === 's3') {
+        $defaultDisk = (string) config('filesystems.default');
+
+        if ($defaultDisk === 's3') {
             return 's3';
         }
 
@@ -347,6 +349,10 @@ class InmuebleController extends Controller
             return 's3';
         }
 
-        return config('filesystems.default', 'public');
+        if ($defaultDisk === 'local' || $defaultDisk === '') {
+            return 'public';
+        }
+
+        return $defaultDisk;
     }
 }


### PR DESCRIPTION
## Summary
- ensure property image uploads fall back to the public disk when the default filesystem is local
- keep support for S3 buckets when configured

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d5c53011308323bc313c4c82f31e37