### PR TITLE
Improve resilience of property image uploads

### DIFF
--- a/app/Http/Controllers/InmuebleController.php
+++ b/app/Http/Controllers/InmuebleController.php
@@ -316,8 +316,9 @@ class InmuebleController extends Controller
         }
 
         $diskName = $this->resolveImageDisk();
+        $fallbackDisk = $diskName === 'public' ? null : 'public';
 
-        $this->imageService->storeImages($inmueble, $imagenes, $diskName);
+        $this->imageService->storeImages($inmueble, $imagenes, $diskName, $fallbackDisk);
     }
 
     /**


### PR DESCRIPTION
## Summary
- pass a fallback disk when persisting gallery images so a local disk can be used when S3 is unavailable
- retry uploads inside `InmuebleImageService` with a cleanup pass and fallback disk to keep S3 failures from losing files and database rows
- defer database inserts until all variants are stored and remove any partially written files before retrying

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d60852116c8323bcbba5ff1104895a