### PR TITLE
Upload property images directly to S3

### DIFF
--- a/app/Http/Controllers/InmuebleController.php
+++ b/app/Http/Controllers/InmuebleController.php
@@ -305,7 +305,7 @@ class InmuebleController extends Controller
     }
 
     /**
-     * Persist uploaded images in S3 (or the configured disk).
+     * Persist uploaded images for the property.
      *
      * @param  array<int, \Illuminate\Http\UploadedFile>  $imagenes
      */
@@ -315,9 +315,7 @@ class InmuebleController extends Controller
             return;
         }
 
-        $diskName = $this->resolveImageDisk();
-
-        $this->imageService->storeImages($inmueble, $imagenes, $diskName);
+        $this->imageService->storeImages($inmueble, $imagenes);
     }
 
     /**
@@ -334,25 +332,4 @@ class InmuebleController extends Controller
         }
     }
 
-    /**
-     * Determine which filesystem disk should be used for property images.
-     */
-    protected function resolveImageDisk(): string
-    {
-        $defaultDisk = (string) config('filesystems.default');
-
-        if ($defaultDisk === 's3') {
-            return 's3';
-        }
-
-        if (! empty(config('filesystems.disks.s3.bucket'))) {
-            return 's3';
-        }
-
-        if ($defaultDisk === 'local' || $defaultDisk === '') {
-            return 'public';
-        }
-
-        return $defaultDisk;
-    }
 }


### PR DESCRIPTION
## Summary
- replace the controller upload helper to delegate directly to the image service without disk fallbacks
- rework `InmuebleImageService` to stream every variant to Amazon S3 using the AWS SDK and create deterministic keys based on the full address
- add helpers to build public URLs, clean up uploaded keys, and delete S3 objects when property images are removed

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d60852116c8323bcbba5ff1104895a