### PR TITLE
Add loader feedback when creating properties

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -89,9 +89,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
             form.dataset.submitting = "true";
 
+            const title = form.dataset.swalLoaderTitle || "Registrando contacto";
+            const text = form.dataset.swalLoaderText || "Estamos guardando la información...";
+
             window.Swal.fire({
-                title: "Registrando contacto",
-                text: "Estamos guardando la información...",
+                title,
+                text,
                 allowOutsideClick: false,
                 allowEscapeKey: false,
                 showConfirmButton: false,

--- a/resources/views/inmuebles/create.blade.php
+++ b/resources/views/inmuebles/create.blade.php
@@ -8,7 +8,15 @@
             </p>
         </div>
 
-        <form action="{{ route('inmuebles.store') }}" method="POST" enctype="multipart/form-data" class="space-y-8">
+        <form
+            action="{{ route('inmuebles.store') }}"
+            method="POST"
+            enctype="multipart/form-data"
+            class="space-y-8"
+            data-swal-loader="registrar-inmueble"
+            data-swal-loader-title="Registrando inmueble"
+            data-swal-loader-text="Estamos guardando la información del inmueble..."
+        >
             @csrf
 
             <x-inmuebles.form


### PR DESCRIPTION
## Summary
- allow forms to customize the SweetAlert loader title and message via data attributes
- show a tailored loader when registering a new property

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d649f7798c83238456e57db064ef8f