### PR TITLE
Remove explicit public ACL from S3 image uploads

### DIFF
--- a/app/Services/InmuebleImageService.php
+++ b/app/Services/InmuebleImageService.php
@@ -178,7 +178,6 @@ class InmuebleImageService
                 'Bucket' => $this->s3Bucket,
                 'Key' => ltrim($key, '/'),
                 'Body' => $stream,
-                'ACL' => 'public-read',
                 'ContentType' => $mimeType,
             ]);
 
@@ -218,7 +217,6 @@ class InmuebleImageService
                 'Bucket' => $this->s3Bucket,
                 'Key' => ltrim($key, '/'),
                 'Body' => $contents,
-                'ACL' => 'public-read',
                 'ContentType' => $mimeType,
             ]);
 


### PR DESCRIPTION
## Summary
- update S3 uploads for inmueble images to rely on the bucket's default access policies
- remove the deprecated public-read ACL parameter from original and processed image uploads

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d64c7e2c988323a618cd2d89ce398a