### PR TITLE
Restore s3_key persistence for property images

### DIFF
--- a/app/Models/InmuebleImage.php
+++ b/app/Models/InmuebleImage.php
@@ -16,6 +16,7 @@ class InmuebleImage extends Model
     protected $fillable = [
         'inmueble_id',
         'disk',
+        's3_key',
         'path',
         'url',
         'orden',

--- a/database/migrations/2025_10_01_000200_create_inmueble_imagenes_table.php
+++ b/database/migrations/2025_10_01_000200_create_inmueble_imagenes_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('inmueble_id')->constrained('inmuebles')->cascadeOnDelete();
             $table->string('disk', 50)->default('s3');
+            $table->string('s3_key');
             $table->string('path');
             $table->string('url');
             $table->unsignedInteger('orden')->default(0);

--- a/database/migrations/2025_10_01_000300_add_s3_key_to_inmueble_imagenes_table.php
+++ b/database/migrations/2025_10_01_000300_add_s3_key_to_inmueble_imagenes_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('inmueble_imagenes', 's3_key')) {
+            Schema::table('inmueble_imagenes', function (Blueprint $table) {
+                $table->string('s3_key')->nullable()->after('path');
+            });
+        }
+
+        DB::table('inmueble_imagenes')
+            ->where(function ($query) {
+                $query->whereNull('s3_key')
+                    ->orWhere('s3_key', '');
+            })
+            ->whereNotNull('path')
+            ->update(['s3_key' => DB::raw('path')]);
+
+        DB::statement('ALTER TABLE inmueble_imagenes MODIFY s3_key VARCHAR(255) NOT NULL');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('inmueble_imagenes', 's3_key')) {
+            Schema::table('inmueble_imagenes', function (Blueprint $table) {
+                $table->dropColumn('s3_key');
+            });
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- persist the S3 key when storing new inmueble images using the address slug and file name
- expose the s3_key attribute on the model and ensure fresh installs create the column
- add a backfill migration that copies existing paths into the s3_key column and enforces the not-null constraint

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d64f8012608323b32da1701db83559