### PR TITLE
Implement temporary URLs for inmueble images

### DIFF
--- a/app/Models/InmuebleImage.php
+++ b/app/Models/InmuebleImage.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Storage;
+use Throwable;
 
 class InmuebleImage extends Model
 {
@@ -51,6 +52,46 @@ class InmuebleImage extends Model
             return $value;
         }
 
-        return Storage::disk($this->disk)->url($this->path);
+        return $this->generateUrlForPath($this->path) ?? $value;
+    }
+
+    public function temporaryVariantUrl(string $variant): ?string
+    {
+        $variantPath = data_get($this->metadata, "variants.$variant.path");
+
+        if (empty($variantPath) || empty($this->disk)) {
+            return null;
+        }
+
+        return $this->generateUrlForPath($variantPath);
+    }
+
+    protected function generateUrlForPath(string $path): ?string
+    {
+        if (empty($this->disk)) {
+            return null;
+        }
+
+        $disk = Storage::disk($this->disk);
+        $expiresAt = now()->addMinutes($this->urlTtlMinutes());
+
+        if (method_exists($disk, 'temporaryUrl')) {
+            try {
+                return $disk->temporaryUrl($path, $expiresAt);
+            } catch (Throwable $exception) {
+                report($exception);
+            }
+        }
+
+        if (method_exists($disk, 'url')) {
+            return $disk->url($path);
+        }
+
+        return null;
+    }
+
+    protected function urlTtlMinutes(): int
+    {
+        return (int) config('inmuebles.images.url_ttl_minutes', 60);
     }
 }

--- a/config/inmuebles.php
+++ b/config/inmuebles.php
@@ -2,6 +2,8 @@
 
 return [
     'images' => [
+        // Tiempo de vida de las URLs temporales generadas para las imágenes.
+        'url_ttl_minutes' => (int) env('INMUEBLES_IMAGE_URL_TTL_MINUTES', 60),
         'quality' => (int) env('INMUEBLES_IMAGE_QUALITY', 85),
         'normalized' => [
             'width' => (int) env('INMUEBLES_IMAGE_WIDTH', 1200),

--- a/resources/views/components/inmuebles/form.blade.php
+++ b/resources/views/components/inmuebles/form.blade.php
@@ -413,7 +413,7 @@
                     @foreach ($inmueble->images as $imagen)
                         <label class="group relative block overflow-hidden rounded-2xl border border-gray-800 bg-gray-900/80 shadow-lg shadow-black/30">
                             <input type="checkbox" name="imagenes_eliminar[]" value="{{ $imagen->id }}" class="absolute right-3 top-3 h-4 w-4 rounded border-gray-600 bg-gray-800 text-red-500 focus:ring-red-400">
-                            <img src="{{ $imagen->url }}" alt="Imagen inmueble" class="h-48 w-full object-cover transition duration-300 group-hover:scale-105">
+                            <img src="{{ $imagen->temporaryVariantUrl('watermarked') ?? $imagen->url }}" alt="Imagen inmueble" class="h-48 w-full object-cover transition duration-300 group-hover:scale-105">
                             <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-3 text-sm text-gray-200">
                                 Marcar para eliminar
                             </div>

--- a/resources/views/inmuebles/index.blade.php
+++ b/resources/views/inmuebles/index.blade.php
@@ -108,7 +108,7 @@
                     <article class="flex flex-col overflow-hidden rounded-3xl border border-gray-800 bg-gray-900/70 shadow-xl shadow-black/30 transition hover:-translate-y-1 hover:border-indigo-500/60">
                         <div class="relative h-56 w-full overflow-hidden">
                             @if ($inmueble->coverImage)
-                                <img src="{{ $inmueble->coverImage->url }}" alt="{{ $inmueble->titulo }}" class="h-full w-full object-cover transition duration-500 group-hover:scale-105">
+                                <img src="{{ $inmueble->coverImage->temporaryVariantUrl('watermarked') ?? $inmueble->coverImage->url }}" alt="{{ $inmueble->titulo }}" class="h-full w-full object-cover transition duration-500 group-hover:scale-105">
                             @else
                                 <div class="flex h-full w-full items-center justify-center bg-gradient-to-br from-gray-800 to-gray-900 text-gray-500">
                                     <span class="text-4xl">🏠</span>

--- a/tests/Feature/InmuebleManagementTest.php
+++ b/tests/Feature/InmuebleManagementTest.php
@@ -64,6 +64,9 @@ class InmuebleManagementTest extends TestCase
 
         $image = InmuebleImage::first();
         $this->assertNotNull($image);
+        $this->assertNull($image->getRawOriginal('url'));
+        $this->assertNotEmpty($image->url);
+        $this->assertNotEmpty($image->temporaryVariantUrl('watermarked'));
 
         $expectedSlug = 'av_del_sol_123_cancun_quintana_roo';
         $this->assertStringStartsWith($expectedSlug . '/', $image->path);
@@ -122,7 +125,7 @@ class InmuebleManagementTest extends TestCase
         $image = $inmueble->images()->create([
             'disk' => 's3',
             'path' => $existingPaths['watermarked'],
-            'url' => Storage::disk('s3')->url($existingPaths['watermarked']),
+            'url' => null,
             'orden' => 1,
             'metadata' => [
                 'variants' => [
@@ -199,7 +202,7 @@ class InmuebleManagementTest extends TestCase
         $inmueble->images()->create([
             'disk' => 's3',
             'path' => $existingPaths['watermarked'],
-            'url' => Storage::disk('s3')->url($existingPaths['watermarked']),
+            'url' => null,
             'orden' => 1,
             'metadata' => [
                 'variants' => [


### PR DESCRIPTION
## Summary
- stop persisting pre-signed URLs on inmueble images and keep only storage metadata
- add configurable TTL for generated image links and expose helpers for variant URLs
- refresh views and tests to rely on regenerated temporary links

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d73b4e3c688323858256fa65e558bc