### PR TITLE
Add Flysystem S3 adapter dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": "^8.2",
         "aws/aws-sdk-php": "^3.356",
+        "league/flysystem-aws-s3-v3": "^3.25",
         "intervention/image": "^3.11",
         "laravel/fortify": "^1.30",
         "laravel/framework": "^12.0",


### PR DESCRIPTION
## Summary
- add the Flysystem AWS S3 v3 adapter to Composer requirements so the S3 disk can be initialized

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d73f18cbf8832391a0d92afd572b48