### PR TITLE
Fix S3 URL generation without Flysystem adapter

### DIFF
--- a/app/Services/InmuebleImageService.php
+++ b/app/Services/InmuebleImageService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\Inmueble;
 use App\Models\InmuebleImage;
+use App\Support\S3Configuration;
 use App\Support\WatermarkPathResolver;
 use Aws\Exception\AwsException;
 use Aws\S3\S3Client;
@@ -34,7 +35,7 @@ class InmuebleImageService
 
     public function __construct(?S3Client $s3Client = null, $imageManager = null)
     {
-        $config = $this->resolveS3Configuration();
+        $config = S3Configuration::resolve();
 
         $this->s3Client = $s3Client ?: new S3Client($config['client']);
         $this->s3Bucket = $config['bucket'];
@@ -311,58 +312,6 @@ class InmuebleImageService
                 );
             }
         }
-    }
-
-    protected function resolveS3Configuration(): array
-    {
-        $diskConfig = (array) config('filesystems.disks.s3', []);
-
-        $bucket = (string) ($diskConfig['bucket'] ?? env('AWS_BUCKET'));
-        $region = (string) ($diskConfig['region'] ?? env('AWS_DEFAULT_REGION'));
-
-        if ($bucket === '' || $region === '') {
-            throw new RuntimeException('La configuración de S3 no está completa. Asegúrate de definir AWS_BUCKET y AWS_DEFAULT_REGION.');
-        }
-
-        $clientConfig = [
-            'version' => 'latest',
-            'region' => $region,
-        ];
-
-        $key = $diskConfig['key'] ?? env('AWS_ACCESS_KEY_ID');
-        $secret = $diskConfig['secret'] ?? env('AWS_SECRET_ACCESS_KEY');
-        $token = $diskConfig['token'] ?? env('AWS_SESSION_TOKEN');
-
-        if ($key && $secret) {
-            $credentials = ['key' => $key, 'secret' => $secret];
-
-            if ($token) {
-                $credentials['token'] = $token;
-            }
-
-            $clientConfig['credentials'] = $credentials;
-        }
-
-        $endpoint = $diskConfig['endpoint'] ?? env('AWS_ENDPOINT');
-
-        if ($endpoint) {
-            $clientConfig['endpoint'] = $endpoint;
-        }
-
-        $pathStyleRaw = $diskConfig['use_path_style_endpoint'] ?? env('AWS_USE_PATH_STYLE_ENDPOINT');
-        $pathStyle = filter_var($pathStyleRaw, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE) ?? false;
-
-        if ($pathStyle) {
-            $clientConfig['use_path_style_endpoint'] = true;
-        }
-
-        return [
-            'client' => $clientConfig,
-            'bucket' => $bucket,
-            'region' => $region,
-            'endpoint' => $endpoint ? (string) $endpoint : null,
-            'path_style' => $pathStyle,
-        ];
     }
 
     protected function storeSingleImage(UploadedFile $image, string $keyPrefix): array

--- a/app/Support/S3Configuration.php
+++ b/app/Support/S3Configuration.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Support;
+
+use RuntimeException;
+
+class S3Configuration
+{
+    /**
+     * Resolve the configuration array used to interact with the S3 bucket.
+     *
+     * @return array{client: array<string, mixed>, bucket: string, region: string, endpoint: ?string, path_style: bool}
+     */
+    public static function resolve(): array
+    {
+        $diskConfig = (array) config('filesystems.disks.s3', []);
+
+        $bucket = (string) ($diskConfig['bucket'] ?? env('AWS_BUCKET'));
+        $region = (string) ($diskConfig['region'] ?? env('AWS_DEFAULT_REGION'));
+
+        if ($bucket === '' || $region === '') {
+            throw new RuntimeException('La configuración de S3 no está completa. Asegúrate de definir AWS_BUCKET y AWS_DEFAULT_REGION.');
+        }
+
+        $clientConfig = [
+            'version' => 'latest',
+            'region' => $region,
+        ];
+
+        $key = $diskConfig['key'] ?? env('AWS_ACCESS_KEY_ID');
+        $secret = $diskConfig['secret'] ?? env('AWS_SECRET_ACCESS_KEY');
+        $token = $diskConfig['token'] ?? env('AWS_SESSION_TOKEN');
+
+        if ($key && $secret) {
+            $credentials = ['key' => $key, 'secret' => $secret];
+
+            if ($token) {
+                $credentials['token'] = $token;
+            }
+
+            $clientConfig['credentials'] = $credentials;
+        }
+
+        $endpoint = $diskConfig['endpoint'] ?? env('AWS_ENDPOINT');
+
+        if ($endpoint) {
+            $clientConfig['endpoint'] = $endpoint;
+        }
+
+        $pathStyleRaw = $diskConfig['use_path_style_endpoint'] ?? env('AWS_USE_PATH_STYLE_ENDPOINT');
+        $pathStyle = filter_var($pathStyleRaw, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE) ?? false;
+
+        if ($pathStyle) {
+            $clientConfig['use_path_style_endpoint'] = true;
+        }
+
+        return [
+            'client' => $clientConfig,
+            'bucket' => $bucket,
+            'region' => $region,
+            'endpoint' => $endpoint ? (string) $endpoint : null,
+            'path_style' => $pathStyle,
+        ];
+    }
+}
+


### PR DESCRIPTION
## Summary
- extract reusable S3 configuration helper
- update the inmueble image service to reuse the shared configuration
- generate presigned S3 URLs directly so the S3 Flysystem adapter is no longer required at runtime

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d7415eea488323bbae26a5734c5336