### PR TITLE
Add gallery add-more button and enforce max file limits

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -283,6 +283,9 @@ document.addEventListener("DOMContentLoaded", () => {
         const emptyState = dropzone?.querySelector(
             "[data-gallery-empty-state]"
         );
+        const addMoreButton = dropzone?.querySelector(
+            "[data-gallery-add-more]"
+        );
         const MAX_FILES = 10;
         const canManageFiles =
             typeof window !== "undefined" &&
@@ -352,10 +355,20 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const updateContainerVisibility = () => {
             const hasFiles = selectedFiles.length > 0;
+            const canAddMore = selectedFiles.length < MAX_FILES;
 
             previewsContainer.classList.toggle("hidden", !hasFiles);
             previewsWrapper?.classList.toggle("hidden", !hasFiles);
             emptyState?.classList.toggle("hidden", hasFiles);
+            addMoreButton?.classList.toggle("hidden", !canAddMore);
+            if (addMoreButton) {
+                addMoreButton.setAttribute(
+                    "aria-disabled",
+                    String(!canAddMore)
+                );
+                addMoreButton.disabled = !canAddMore;
+            }
+            galleryInput.disabled = !canAddMore;
             updateFileCount();
         };
 
@@ -497,6 +510,8 @@ document.addEventListener("DOMContentLoaded", () => {
         };
 
         if (dropzone) {
+            const atMaxFiles = () => selectedFiles.length >= MAX_FILES;
+
             const handleFileDrop = (event) => {
                 if (!isFileDragEvent(event)) {
                     return;
@@ -504,6 +519,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
                 event.preventDefault();
                 setDropzoneActive(false);
+
+                if (atMaxFiles()) {
+                    return;
+                }
 
                 const files = Array.from(event.dataTransfer?.files || []);
 
@@ -545,6 +564,10 @@ document.addEventListener("DOMContentLoaded", () => {
                     return;
                 }
 
+                if (atMaxFiles()) {
+                    return;
+                }
+
                 galleryInput.click();
             });
 
@@ -558,6 +581,24 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
 
                 event.preventDefault();
+
+                if (atMaxFiles()) {
+                    return;
+                }
+
+                galleryInput.click();
+            });
+        }
+
+        if (addMoreButton) {
+            addMoreButton.addEventListener("click", (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+
+                if (selectedFiles.length >= MAX_FILES) {
+                    return;
+                }
+
                 galleryInput.click();
             });
         }

--- a/resources/views/components/inmuebles/form.blade.php
+++ b/resources/views/components/inmuebles/form.blade.php
@@ -398,6 +398,17 @@
                             </template>
                         </div>
                     </div>
+                    <button
+                        type="button"
+                        class="inline-flex items-center gap-2 self-center rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-medium text-indigo-200 transition hover:bg-indigo-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+                        data-gallery-add-more
+                        aria-disabled="false"
+                    >
+                        <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M10 4v9m0 0 3-3m-3 3-3-3" />
+                        </svg>
+                        Seleccionar imágenes
+                    </button>
                     <p class="text-xs text-gray-400 transition-colors" data-gallery-counter>0 de 10 imágenes seleccionadas</p>
                     <p class="text-xs text-gray-500">Formatos permitidos: JPG y PNG</p>
                 </div>


### PR DESCRIPTION
## Summary
- add a dedicated “Seleccionar imágenes” button inside the gallery dropzone
- show or hide the button while disabling the file input when the max limit is reached
- guard dropzone interactions so clicks, key presses, and drops exit early at the file cap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d74cb1d1648323b069aa30c4b0fe67