### PR TITLE
Remove drag interactions from gallery dropzone

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -296,17 +296,6 @@ document.addEventListener("DOMContentLoaded", () => {
         let dragSourcePreview = null;
         let dragPlaceholder = null;
 
-        const setDropzoneActive = (isActive) => {
-            if (!dropzone) {
-                return;
-            }
-
-            dropzone.classList.toggle("border-indigo-400/70", isActive);
-            dropzone.classList.toggle("bg-gray-850/80", isActive);
-            dropzone.classList.toggle("shadow-lg", isActive);
-            dropzone.classList.toggle("shadow-indigo-500/30", isActive);
-        };
-
         const isFileDragEvent = (event) => {
             if (!event || !event.dataTransfer) {
                 return false;
@@ -614,50 +603,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
         if (dropzone) {
             const atMaxFiles = () => selectedFiles.length >= MAX_FILES;
-
-            const handleFileDrop = (event) => {
-                if (!isFileDragEvent(event)) {
-                    return;
-                }
-
+            dropzone.addEventListener("drop", (event) => {
                 event.preventDefault();
-                setDropzoneActive(false);
-
-                if (atMaxFiles()) {
-                    return;
-                }
-
-                const files = Array.from(event.dataTransfer?.files || []);
-
-                addFilesToSelection(files);
-            };
-
-            ["dragenter", "dragover"].forEach((type) => {
-                dropzone.addEventListener(type, (event) => {
-                    if (!isFileDragEvent(event)) {
-                        return;
-                    }
-
-                    event.preventDefault();
-                    setDropzoneActive(true);
-                });
             });
-
-            dropzone.addEventListener("dragleave", (event) => {
-                if (!isFileDragEvent(event)) {
-                    return;
-                }
-
-                const related = event.relatedTarget;
-
-                if (related instanceof Element && dropzone.contains(related)) {
-                    return;
-                }
-
-                setDropzoneActive(false);
-            });
-
-            dropzone.addEventListener("drop", handleFileDrop);
 
             dropzone.addEventListener("click", (event) => {
                 if (
@@ -799,7 +747,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
         previewsContainer.addEventListener("dragenter", (event) => {
             if (isFileDragEvent(event)) {
-                setDropzoneActive(true);
                 return;
             }
 
@@ -824,7 +771,6 @@ document.addEventListener("DOMContentLoaded", () => {
         previewsContainer.addEventListener("dragover", (event) => {
             if (isFileDragEvent(event)) {
                 event.preventDefault();
-                setDropzoneActive(true);
                 return;
             }
 
@@ -855,7 +801,6 @@ document.addEventListener("DOMContentLoaded", () => {
         previewsContainer.addEventListener("drop", (event) => {
             if (isFileDragEvent(event)) {
                 event.preventDefault();
-                setDropzoneActive(false);
 
                 const files = Array.from(event.dataTransfer?.files || []);
 
@@ -925,18 +870,6 @@ document.addEventListener("DOMContentLoaded", () => {
                 removePlaceholder();
                 return;
             }
-
-            const related = event.relatedTarget;
-
-            if (
-                related instanceof Element &&
-                (related.closest("[data-gallery-preview]") ||
-                    dropzone?.contains(related))
-            ) {
-                return;
-            }
-
-            setDropzoneActive(false);
         });
 
         updateContainerVisibility();

--- a/resources/views/components/inmuebles/form.blade.php
+++ b/resources/views/components/inmuebles/form.blade.php
@@ -333,10 +333,7 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5m-15 12.75h13.5A1.5 1.5 0 0 0 20.25 18V6a1.5 1.5 0 0 0-1.5-1.5H5.25A1.5 1.5 0 0 0 3.75 6v12a1.5 1.5 0 0 0 1.5 1.5Zm5.25-3.75h4.5a1.5 1.5 0 0 0 1.29-2.295l-2.25-3.75a1.5 1.5 0 0 0-2.58 0l-2.25 3.75A1.5 1.5 0 0 0 9 15.75Z" />
                             </svg>
                         </div>
-                        <div class="space-y-1">
-                            <p class="text-sm font-medium text-gray-100">Arrastra y suelta tus fotos</p>
-                            <p class="text-xs text-gray-400">También puedes hacer clic para seleccionarlas desde tu dispositivo</p>
-                        </div>
+                        <p class="text-sm font-medium text-gray-100">Haz clic para seleccionar tus fotos</p>
                     </div>
                     <div class="hidden w-full space-y-3 text-left" data-gallery-previews-wrapper>
                         <p class="text-xs text-gray-400">Arrastra las fotos para cambiar el orden. La primera será la portada.</p>


### PR DESCRIPTION
## Summary
- update the gallery empty state copy to only mention clicking to select photos
- remove the dropzone drag-and-drop handlers and related highlighting helper so the input only opens on click/keyboard

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d751fd9268832394420e8fe9968a7b