### PR TITLE
Default status for new inmueble records

### DIFF
--- a/app/Http/Controllers/InmuebleController.php
+++ b/app/Http/Controllers/InmuebleController.php
@@ -83,10 +83,7 @@ class InmuebleController extends Controller
      */
     public function create(): View
     {
-        $statuses = InmuebleStatus::orderBy('orden')->orderBy('nombre')->get();
-
         return view('inmuebles.create', [
-            'statuses' => $statuses,
             'tipos' => Inmueble::TIPOS,
             'operaciones' => Inmueble::OPERACIONES,
             'watermarkPreviewUrl' => $this->getWatermarkPreviewUrl(),
@@ -101,6 +98,10 @@ class InmuebleController extends Controller
 
         $payload = $this->preparePayload($request->validated(), $request);
         $imagenes = $request->file('imagenes', []);
+
+        if (! array_key_exists('estatus_id', $payload) || $payload['estatus_id'] === null) {
+            $payload['estatus_id'] = 1;
+        }
 
         DB::transaction(function () use ($payload, $imagenes): void {
             $inmueble = Inmueble::create($payload);

--- a/app/Http/Requests/StoreInmuebleRequest.php
+++ b/app/Http/Requests/StoreInmuebleRequest.php
@@ -33,7 +33,7 @@ class StoreInmuebleRequest extends FormRequest
             'codigo_postal' => ['nullable', 'string', 'max:20'],
             'tipo' => ['required', Rule::in(Inmueble::TIPOS)],
             'operacion' => ['required', Rule::in(Inmueble::OPERACIONES)],
-            'estatus_id' => ['required', 'integer', Rule::exists('inmueble_estatus', 'id')],
+            'estatus_id' => ['sometimes', 'integer', Rule::exists('inmueble_estatus', 'id')],
             'habitaciones' => ['nullable', 'integer', 'min:0', 'max:50'],
             'banos' => ['nullable', 'integer', 'min:0', 'max:50'],
             'estacionamientos' => ['nullable', 'integer', 'min:0', 'max:50'],

--- a/app/Http/Requests/UpdateInmuebleRequest.php
+++ b/app/Http/Requests/UpdateInmuebleRequest.php
@@ -15,6 +15,8 @@ class UpdateInmuebleRequest extends StoreInmuebleRequest
     {
         $rules = parent::rules();
 
+        $rules['estatus_id'] = ['required', 'integer', Rule::exists('inmueble_estatus', 'id')];
+
         $rules['imagenes'] = ['nullable', 'array', 'max:10'];
         $rules['imagenes.*'] = ['image', 'max:5120'];
         $rules['imagenes_eliminar'] = ['nullable', 'array'];

--- a/resources/views/components/inmuebles/form.blade.php
+++ b/resources/views/components/inmuebles/form.blade.php
@@ -1,6 +1,7 @@
 @props([
     'inmueble' => null,
     'statuses' => collect(),
+    'showStatusSelector' => true,
     'tipos' => [],
     'operaciones' => [],
     'watermarkPreviewUrl' => null,
@@ -117,7 +118,7 @@
                 </div>
             </div>
 
-            <div class="grid gap-5 lg:grid-cols-3">
+            <div class="grid gap-5 {{ $showStatusSelector ? 'lg:grid-cols-3' : 'lg:grid-cols-2' }}">
                 <div class="space-y-2">
                     <label for="tipo" class="text-sm font-medium">Tipo *</label>
                     <select
@@ -154,25 +155,27 @@
                     @enderror
                 </div>
 
-                <div class="space-y-2">
-                    <label for="estatus_id" class="text-sm font-medium">Estatus *</label>
-                    <select
-                        id="estatus_id"
-                        name="estatus_id"
-                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                        required
-                    >
-                        <option value="">Selecciona un estado</option>
-                        @foreach ($statuses as $status)
-                            <option value="{{ $status->id }}" @selected((int) old('estatus_id', optional($inmueble)->estatus_id) === $status->id)>
-                                {{ $status->nombre }}
-                            </option>
-                        @endforeach
-                    </select>
-                    @error('estatus_id')
-                        <p class="text-sm text-red-400">{{ $message }}</p>
-                    @enderror
-                </div>
+                @if ($showStatusSelector)
+                    <div class="space-y-2">
+                        <label for="estatus_id" class="text-sm font-medium">Estatus *</label>
+                        <select
+                            id="estatus_id"
+                            name="estatus_id"
+                            class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            required
+                        >
+                            <option value="">Selecciona un estado</option>
+                            @foreach ($statuses as $status)
+                                <option value="{{ $status->id }}" @selected((int) old('estatus_id', optional($inmueble)->estatus_id) === $status->id)>
+                                    {{ $status->nombre }}
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('estatus_id')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+                @endif
             </div>
 
             <div class="space-y-2">

--- a/resources/views/inmuebles/create.blade.php
+++ b/resources/views/inmuebles/create.blade.php
@@ -20,10 +20,10 @@
             @csrf
 
             <x-inmuebles.form
-                :statuses="$statuses"
                 :tipos="$tipos"
                 :operaciones="$operaciones"
                 :watermark-preview-url="$watermarkPreviewUrl"
+                :show-status-selector="false"
             />
 
             <div class="flex flex-col items-stretch gap-3 border-t border-gray-800 pt-6 sm:flex-row sm:justify-between">


### PR DESCRIPTION
## Summary
- hide the status selector in the create inmueble flow while keeping it for edits
- default new inmueble records to status ID 1 when no status is provided
- relax create validation for the status field but keep it required when updating

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d75dc3e92483238e21a5e9c2572779