### PR TITLE
Fix contacts index showing empty results

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -25,9 +25,6 @@ class ContactController extends Controller
                         ->orWhere('email', 'like', "%{$search}%");
                 });
             })
-            ->when($search === '', function ($query) {
-                $query->whereRaw('0 = 1');
-            })
             ->orderByDesc('id')
             ->paginate(12)
             ->withQueryString();


### PR DESCRIPTION
## Summary
- remove the empty-search guard that filtered out every contact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d77587a85483238e95c52def761708