### PR TITLE
Actualizar vistas con colonia y municipio en ubicaciones

### DIFF
--- a/resources/views/contacts/create.blade.php
+++ b/resources/views/contacts/create.blade.php
@@ -84,12 +84,20 @@
                             >
                                 <option value="">Sin inmueble registrado</option>
                                 @foreach ($inmuebles as $inmueble)
+                                    @php
+                                        $fullAddress = collect([
+                                            $inmueble->direccion,
+                                            $inmueble->colonia,
+                                            $inmueble->municipio,
+                                            $inmueble->estado,
+                                        ])->filter()->join(', ');
+                                    @endphp
                                     <option
                                         value="{{ $inmueble->id }}"
-                                        data-searchable="{{ Str::lower($inmueble->titulo . ' ' . $inmueble->direccion) }}"
+                                        data-searchable="{{ Str::lower(trim($inmueble->titulo . ' ' . $fullAddress)) }}"
                                         @selected((string) old('inmueble_id') === (string) $inmueble->id)
                                     >
-                                        {{ $inmueble->titulo }} — {{ $inmueble->direccion }}
+                                        {{ $inmueble->titulo }}@if ($fullAddress !== '') — {{ $fullAddress }}@endif
                                     </option>
                                 @endforeach
                             </select>

--- a/resources/views/contacts/show.blade.php
+++ b/resources/views/contacts/show.blade.php
@@ -107,8 +107,16 @@
                                 >
                                     <option value="" disabled selected>Selecciona un inmueble</option>
                                     @foreach ($inmuebles as $inmueble)
-                                        <option value="{{ $inmueble->id }}" data-searchable="{{ Str::lower($inmueble->titulo . ' ' . $inmueble->direccion) }}">
-                                            {{ $inmueble->titulo }} — {{ $inmueble->direccion }}
+                                        @php
+                                            $fullAddress = collect([
+                                                $inmueble->direccion,
+                                                $inmueble->colonia,
+                                                $inmueble->municipio,
+                                                $inmueble->estado,
+                                            ])->filter()->join(', ');
+                                        @endphp
+                                        <option value="{{ $inmueble->id }}" data-searchable="{{ Str::lower(trim($inmueble->titulo . ' ' . $fullAddress)) }}">
+                                            {{ $inmueble->titulo }}@if ($fullAddress !== '') — {{ $fullAddress }}@endif
                                         </option>
                                     @endforeach
                                 </select>
@@ -130,7 +138,17 @@
                                     <h3 class="font-semibold text-indigo-200">{{ optional($interes->inmueble)->titulo ?? 'Inmueble sin título' }}</h3>
                                     <p class="text-sm text-gray-400">Registrado el {{ optional($interes->created_at)->format('d/m/Y H:i') ?? '—' }}</p>
                                     @if ($interes->inmueble)
-                                        <p class="mt-2 text-sm text-gray-300">{{ $interes->inmueble->direccion }} · {{ $interes->inmueble->tipo }} en {{ $interes->inmueble->operacion }}</p>
+                                        @php
+                                            $fullAddress = collect([
+                                                $interes->inmueble->direccion,
+                                                $interes->inmueble->colonia,
+                                                $interes->inmueble->municipio,
+                                                $interes->inmueble->estado,
+                                            ])->filter()->join(', ');
+                                        @endphp
+                                        <p class="mt-2 text-sm text-gray-300">
+                                            {{ $fullAddress !== '' ? $fullAddress : 'Dirección no disponible' }} · {{ $interes->inmueble->tipo }} en {{ $interes->inmueble->operacion }}
+                                        </p>
                                     @endif
                                 </article>
                             @empty

--- a/resources/views/inmuebles/index.blade.php
+++ b/resources/views/inmuebles/index.blade.php
@@ -127,9 +127,14 @@
                                 </div>
                                 <h2 class="text-xl font-semibold text-white">{{ $inmueble->titulo }}</h2>
                                 @php
-                                    $location = collect([$inmueble->colonia, $inmueble->municipio, $inmueble->estado])->filter()->join(', ');
+                                    $fullAddress = collect([
+                                        $inmueble->direccion,
+                                        $inmueble->colonia,
+                                        $inmueble->municipio,
+                                        $inmueble->estado,
+                                    ])->filter()->join(', ');
                                 @endphp
-                                <p class="text-sm text-gray-400">{{ $inmueble->direccion }}@if ($location){{ ', ' . $location }}@endif</p>
+                                <p class="text-sm text-gray-400">{{ $fullAddress }}</p>
                             </div>
 
                             <div class="flex flex-wrap items-center gap-3 text-sm text-gray-300">


### PR DESCRIPTION
## Summary
- mostrar la dirección completa concatenando colonia y municipio en el listado de inmuebles
- actualizar selectores de inmuebles en contactos para incluir colonia y municipio en las búsquedas y etiquetas
- mostrar direcciones completas en los historiales de interés de contactos

## Testing
- no se ejecutaron pruebas (no testing requested)


------
https://chatgpt.com/codex/tasks/task_e_68d77792633c8323957ad9c85ab6dc41