### PR TITLE
Adjust inmueble data generation for colonia and municipio

### DIFF
--- a/database/factories/InmuebleFactory.php
+++ b/database/factories/InmuebleFactory.php
@@ -28,7 +28,7 @@ class InmuebleFactory extends Factory
             'descripcion' => $this->faker->paragraph(),
             'precio' => $this->faker->randomFloat(2, 1000000, 20000000),
             'direccion' => $this->faker->streetAddress(),
-            'colonia' => $this->faker->streetName(),
+            'colonia' => $this->faker->words(2, true),
             'municipio' => $this->faker->city(),
             'estado' => $this->faker->state(),
             'codigo_postal' => $this->faker->postcode(),

--- a/tests/Feature/InmuebleManagementTest.php
+++ b/tests/Feature/InmuebleManagementTest.php
@@ -6,6 +6,7 @@ use App\Models\Inmueble;
 use App\Models\InmuebleImage;
 use App\Models\InmuebleStatus;
 use App\Models\User;
+use App\Support\AddressSlugger;
 use Database\Seeders\InmuebleStatusSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
@@ -61,6 +62,8 @@ class InmuebleManagementTest extends TestCase
             'titulo' => 'Casa en la playa',
             'asesor_id' => $user->id,
             'operacion' => 'Venta',
+            'colonia' => 'Centro',
+            'municipio' => 'Benito Juárez',
         ]);
 
         $image = InmuebleImage::first();
@@ -69,7 +72,12 @@ class InmuebleManagementTest extends TestCase
         $this->assertNotEmpty($image->url);
         $this->assertNotEmpty($image->temporaryVariantUrl('watermarked'));
 
-        $expectedSlug = 'av_del_sol_123_centro_benito_juarez_quintana_roo';
+        $expectedSlug = AddressSlugger::fromArray([
+            'Av. del Sol 123',
+            'Centro',
+            'Benito Juárez',
+            'Quintana Roo',
+        ]);
         $this->assertStringStartsWith($expectedSlug . '/', $image->path);
         $this->assertStringContainsString('_watermarked.jpg', $image->path);
 
@@ -112,7 +120,12 @@ class InmuebleManagementTest extends TestCase
             'estatus_id' => $status->id,
         ]);
 
-        $basePath = 'av_reforma_101_colonia_juarez_cuauhtemoc_ciudad_de_mexico';
+        $basePath = AddressSlugger::fromArray([
+            'Av. Reforma 101',
+            'Colonia Juárez',
+            'Cuauhtémoc',
+            'Ciudad de México',
+        ]);
         $existingPaths = [
             'original' => "$basePath/original_original.jpg",
             'normalized' => "$basePath/original_normalized.jpg",
@@ -191,7 +204,12 @@ class InmuebleManagementTest extends TestCase
             'estatus_id' => $status->id,
         ]);
 
-        $slugPath = 'calle_arte_55_americana_guadalajara_jalisco';
+        $slugPath = AddressSlugger::fromArray([
+            'Calle Arte 55',
+            'Americana',
+            'Guadalajara',
+            'Jalisco',
+        ]);
         $existingPaths = [
             'original' => "$slugPath/loft_original.jpg",
             'normalized' => "$slugPath/loft_normalized.jpg",


### PR DESCRIPTION
## Summary
- ensure the inmueble factory now populates colonia and municipio fields with coherent fake data
- update inmueble management feature tests to send the new address fields and derive slugs with the adjusted component order

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d7788449548323bab6ef19de62c09c