### PR TITLE
Add postal code catalog endpoints

### DIFF
--- a/app/Http/Controllers/CodigoPostalController.php
+++ b/app/Http/Controllers/CodigoPostalController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CodigoPostal;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class CodigoPostalController extends Controller
+{
+    /**
+     * Column map for allowed query parameters.
+     *
+     * @var array<string, string>
+     */
+    protected array $columnMap = [
+        'codigo_postal' => 'd_codigo',
+        'colonia' => 'd_asenta',
+        'municipio' => 'd_mnpio',
+        'estado' => 'd_estado',
+        'ciudad' => 'd_ciudad',
+    ];
+
+    /**
+     * List unique postal code values based on the requested type and filters.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $request->validate($this->getValidationRules(['search' => ['nullable', 'string', 'max:255']]));
+
+        $column = $this->columnMap[$validated['type']];
+
+        $query = CodigoPostal::query()
+            ->select($column)
+            ->whereNotNull($column);
+
+        foreach ($this->columnMap as $parameter => $field) {
+            if (!array_key_exists($parameter, $validated) || $parameter === $validated['type']) {
+                continue;
+            }
+
+            $value = $validated[$parameter];
+
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            $query->where($field, $value);
+        }
+
+        if (!empty($validated['search'])) {
+            $query->where($column, 'like', '%' . $validated['search'] . '%');
+        }
+
+        $values = $query
+            ->distinct()
+            ->orderBy($column)
+            ->limit(50)
+            ->pluck($column)
+            ->filter()
+            ->values();
+
+        return response()->json([
+            'data' => $values,
+        ]);
+    }
+
+    /**
+     * Resolve complete postal code information using a selected value.
+     */
+    public function resolve(Request $request): JsonResponse
+    {
+        $validated = $request->validate($this->getValidationRules([
+            'value' => ['required', 'string', 'max:255'],
+        ], ['search']));
+
+        $column = $this->columnMap[$validated['type']];
+
+        $query = CodigoPostal::query()
+            ->select(array_values($this->columnMap));
+
+        foreach ($this->columnMap as $parameter => $field) {
+            $value = $validated[$parameter] ?? null;
+
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            $query->where($field, $value);
+        }
+
+        $query->where($column, $validated['value']);
+
+        $results = $query
+            ->distinct()
+            ->orderBy('d_asenta')
+            ->orderBy('d_mnpio')
+            ->orderBy('d_estado')
+            ->orderBy('d_codigo')
+            ->get()
+            ->map(fn (CodigoPostal $codigoPostal) => [
+                'codigo_postal' => $codigoPostal->d_codigo,
+                'colonia' => $codigoPostal->d_asenta,
+                'municipio' => $codigoPostal->d_mnpio,
+                'estado' => $codigoPostal->d_estado,
+                'ciudad' => $codigoPostal->d_ciudad,
+            ]);
+
+        return response()->json([
+            'data' => $results,
+        ]);
+    }
+
+    /**
+     * Build validation rules for postal code queries.
+     *
+     * @param  array<string, array<int, string>>  $additional
+     * @param  array<int, string>  $exclusions
+     * @return array<string, mixed>
+     */
+    protected function getValidationRules(array $additional = [], array $exclusions = []): array
+    {
+        $rules = array_merge([
+            'type' => ['required', Rule::in(array_keys($this->columnMap))],
+        ], $additional);
+
+        foreach ($this->columnMap as $parameter => $field) {
+            if (in_array($parameter, $exclusions, true)) {
+                continue;
+            }
+
+            $rules[$parameter] = ['nullable', 'string', 'max:255'];
+        }
+
+        return $rules;
+    }
+}

--- a/app/Models/CodigoPostal.php
+++ b/app/Models/CodigoPostal.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CodigoPostal extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'codigos_postales';
+
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'd_codigo',
+        'd_asenta',
+        'd_mnpio',
+        'd_estado',
+        'd_ciudad',
+    ];
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CodigoPostalController;
 use App\Http\Controllers\ContactController;
 use App\Http\Controllers\InmuebleController;
 use Illuminate\Support\Facades\Route;
@@ -50,6 +51,18 @@ Route::middleware(['auth'])->group(function () {
         ->name('contactos.intereses.store');
 
     Route::resource('inmuebles', InmuebleController::class)->except(['show']);
+
+    Route::prefix('catalogos')->name('catalogos.')->group(function () {
+        Route::get('codigos-postales', [CodigoPostalController::class, 'index'])
+            ->name('codigos-postales.index');
+        Route::get('codigos-postales/resolve', [CodigoPostalController::class, 'resolve'])
+            ->name('codigos-postales.resolve');
+    });
+
+    Route::get('codigos-postales', [CodigoPostalController::class, 'index'])
+        ->name('codigos-postales.index');
+    Route::get('codigos-postales/resolve', [CodigoPostalController::class, 'resolve'])
+        ->name('codigos-postales.resolve');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
## Summary
- add a CodigoPostal model mapped to the codigos_postales table
- implement CodigoPostalController with index and resolve actions that validate input and return JSON responses
- register authenticated catalog routes for postal code lookups

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d77dd08bc48323a7eb238f34408935