### PR TITLE
Refine inmueble form UI styling

### DIFF
--- a/resources/views/components/inmuebles/form.blade.php
+++ b/resources/views/components/inmuebles/form.blade.php
@@ -14,26 +14,30 @@
     $selectedColonia = old('colonia', optional($inmueble)->colonia);
     $selectedMunicipio = old('municipio', optional($inmueble)->municipio);
     $selectedEstado = old('estado', optional($inmueble)->estado);
+
+    $formControlClasses = 'w-full rounded-2xl border border-gray-700/70 bg-gray-900/60 px-4 py-3 text-gray-100 placeholder-gray-500 shadow-sm shadow-black/20 transition duration-200 ease-out focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/40';
+    $selectControlClasses = $formControlClasses . ' pr-10 appearance-none';
+    $textareaControlClasses = $formControlClasses . ' min-h-[3rem]';
 @endphp
 
-<div class="space-y-8">
-    <section class="rounded-3xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/30">
+<div class="space-y-10">
+    <section class="rounded-3xl border border-white/5 bg-gradient-to-br from-gray-950/90 via-gray-900/70 to-gray-950/80 p-8 shadow-2xl shadow-black/40 backdrop-blur">
         <div class="space-y-6">
             <div>
-                <h2 class="text-lg font-semibold">Información general</h2>
+                <h2 class="text-lg font-semibold text-gray-100">Información general</h2>
                 <p class="text-sm text-gray-400">Agrega los datos principales del inmueble que se mostrarán en la ficha pública.</p>
             </div>
 
-            <div class="grid gap-5 lg:grid-cols-2">
-                <div class="space-y-2">
-                    <label for="titulo" class="text-sm font-medium">Título *</label>
+            <div class="grid gap-6 lg:grid-cols-12">
+                <div class="space-y-3 lg:col-span-7">
+                    <label for="titulo" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Título *</label>
                     <input
                         type="text"
                         id="titulo"
                         name="titulo"
                         value="{{ old('titulo', optional($inmueble)->titulo) }}"
                         placeholder="Ej. Departamento moderno con terraza"
-                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        class="{{ $formControlClasses }}"
                         required
                     >
                     @error('titulo')
@@ -41,10 +45,10 @@
                     @enderror
                 </div>
 
-                <div class="space-y-2">
-                    <label for="precio" class="text-sm font-medium">Precio *</label>
+                <div class="space-y-3 lg:col-span-5">
+                    <label for="precio" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Precio *</label>
                     <div class="relative">
-                        <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-400">$</span>
+                        <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-500">$</span>
                         <input
                             type="number"
                             step="0.01"
@@ -52,7 +56,7 @@
                             id="precio"
                             name="precio"
                             value="{{ old('precio', optional($inmueble)->precio) }}"
-                            class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 pl-7 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            class="{{ $formControlClasses }} pl-8"
                             required
                         >
                     </div>
@@ -62,16 +66,16 @@
                 </div>
             </div>
 
-            <div class="grid gap-5 lg:grid-cols-2">
-                <div class="space-y-2">
-                    <label for="direccion" class="text-sm font-medium">Dirección *</label>
+            <div class="grid gap-6 lg:grid-cols-12">
+                <div class="space-y-3 lg:col-span-7">
+                    <label for="direccion" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Dirección *</label>
                     <input
                         type="text"
                         id="direccion"
                         name="direccion"
                         value="{{ old('direccion', optional($inmueble)->direccion) }}"
                         placeholder="Calle y número"
-                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        class="{{ $formControlClasses }}"
                         required
                     >
                     @error('direccion')
@@ -80,25 +84,25 @@
                 </div>
 
                 <div
-                    class="grid grid-cols-1 gap-4"
+                    class="grid grid-cols-1 gap-4 lg:col-span-5"
                     data-postal-selector
                     data-postal-options-url="{{ url('/codigos-postales') }}"
                 >
-                    <div class="space-y-2">
-                        <label for="codigo_postal" class="text-sm font-medium">C.P.</label>
+                    <div class="space-y-3">
+                        <label for="codigo_postal" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">C.P.</label>
                         <div class="space-y-2" data-searchable-select>
                             <input
                                 type="search"
                                 id="codigo-postal-search"
                                 data-search-input
                                 placeholder="Buscar C.P."
-                                class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                                class="{{ $formControlClasses }}"
                                 autocomplete="off"
                             >
                             <select
                                 id="codigo_postal"
                                 name="codigo_postal"
-                                class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                                class="{{ $selectControlClasses }}"
                             >
                                 <option value="">Selecciona una opción</option>
                                 @if ($selectedCodigoPostal)
@@ -116,21 +120,21 @@
                             <p class="text-sm text-red-400">{{ $message }}</p>
                         @enderror
                     </div>
-                    <div class="space-y-2">
-                        <label for="colonia" class="text-sm font-medium">Colonia</label>
+                    <div class="space-y-3">
+                        <label for="colonia" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Colonia</label>
                         <div class="space-y-2" data-searchable-select>
                             <input
                                 type="search"
                                 id="colonia-search"
                                 data-search-input
                                 placeholder="Buscar colonia"
-                                class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                                class="{{ $formControlClasses }}"
                                 autocomplete="off"
                             >
                             <select
                                 id="colonia"
                                 name="colonia"
-                                class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                                class="{{ $selectControlClasses }}"
                             >
                                 <option value="">Selecciona una opción</option>
                                 @if ($selectedColonia)
@@ -148,21 +152,21 @@
                             <p class="text-sm text-red-400">{{ $message }}</p>
                         @enderror
                     </div>
-                    <div class="space-y-2">
-                        <label for="municipio" class="text-sm font-medium">Municipio</label>
+                    <div class="space-y-3">
+                        <label for="municipio" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Municipio</label>
                         <div class="space-y-2" data-searchable-select>
                             <input
                                 type="search"
                                 id="municipio-search"
                                 data-search-input
                                 placeholder="Buscar municipio"
-                                class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                                class="{{ $formControlClasses }}"
                                 autocomplete="off"
                             >
                             <select
                                 id="municipio"
                                 name="municipio"
-                                class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                                class="{{ $selectControlClasses }}"
                             >
                                 <option value="">Selecciona una opción</option>
                                 @if ($selectedMunicipio)
@@ -180,21 +184,21 @@
                             <p class="text-sm text-red-400">{{ $message }}</p>
                         @enderror
                     </div>
-                    <div class="space-y-2">
-                        <label for="estado" class="text-sm font-medium">Estado</label>
+                    <div class="space-y-3">
+                        <label for="estado" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Estado</label>
                         <div class="space-y-2" data-searchable-select>
                             <input
                                 type="search"
                                 id="estado-search"
                                 data-search-input
                                 placeholder="Buscar estado"
-                                class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                                class="{{ $formControlClasses }}"
                                 autocomplete="off"
                             >
                             <select
                                 id="estado"
                                 name="estado"
-                                class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                                class="{{ $selectControlClasses }}"
                             >
                                 <option value="">Selecciona una opción</option>
                                 @if ($selectedEstado)
@@ -216,12 +220,12 @@
             </div>
 
             <div class="grid gap-5 {{ $showStatusSelector ? 'lg:grid-cols-3' : 'lg:grid-cols-2' }}">
-                <div class="space-y-2">
-                    <label for="tipo" class="text-sm font-medium">Tipo *</label>
+                <div class="space-y-3">
+                    <label for="tipo" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Tipo *</label>
                     <select
                         id="tipo"
                         name="tipo"
-                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        class="{{ $selectControlClasses }}"
                         required
                     >
                         <option value="">Selecciona una opción</option>
@@ -234,12 +238,12 @@
                     @enderror
                 </div>
 
-                <div class="space-y-2">
-                    <label for="operacion" class="text-sm font-medium">Operación *</label>
+                <div class="space-y-3">
+                    <label for="operacion" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Operación *</label>
                     <select
                         id="operacion"
                         name="operacion"
-                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        class="{{ $selectControlClasses }}"
                         required
                     >
                         <option value="">Selecciona una opción</option>
@@ -253,12 +257,12 @@
                 </div>
 
                 @if ($showStatusSelector)
-                    <div class="space-y-2">
-                        <label for="estatus_id" class="text-sm font-medium">Estatus *</label>
+                    <div class="space-y-3">
+                        <label for="estatus_id" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Estatus *</label>
                         <select
                             id="estatus_id"
                             name="estatus_id"
-                            class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            class="{{ $selectControlClasses }}"
                             required
                         >
                             <option value="">Selecciona un estado</option>
@@ -275,13 +279,13 @@
                 @endif
             </div>
 
-            <div class="space-y-2">
-                <label for="descripcion" class="text-sm font-medium">Descripción</label>
+            <div class="space-y-3">
+                <label for="descripcion" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Descripción</label>
                 <textarea
                     id="descripcion"
                     name="descripcion"
                     rows="5"
-                    class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    class="{{ $textareaControlClasses }}"
                     placeholder="Cuenta la historia del inmueble, puntos fuertes y contexto del vecindario"
                 >{{ old('descripcion', optional($inmueble)->descripcion) }}</textarea>
                 @error('descripcion')
@@ -291,11 +295,11 @@
         </div>
     </section>
 
-    <section class="rounded-3xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/30">
+    <section class="rounded-3xl border border-white/5 bg-gradient-to-br from-gray-950/90 via-gray-900/70 to-gray-950/80 p-8 shadow-2xl shadow-black/40 backdrop-blur">
         <div class="space-y-6">
             <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                    <h2 class="text-lg font-semibold">Características</h2>
+                    <h2 class="text-lg font-semibold text-gray-100">Características</h2>
                     <p class="text-sm text-gray-400">Detalle los elementos que ayudan a tomar decisiones rápidas.</p>
                 </div>
                 <label class="inline-flex items-center gap-2 text-sm font-medium">
@@ -318,8 +322,8 @@
                 @endphp
 
                 @foreach ($featureFields as $field)
-                    <div class="space-y-2">
-                        <label for="{{ $field['id'] }}" class="text-sm font-medium">{{ $field['label'] }}</label>
+                    <div class="space-y-3">
+                        <label for="{{ $field['id'] }}" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">{{ $field['label'] }}</label>
                         <input
                             type="number"
                             @if (isset($field['step'])) step="{{ $field['step'] }}" @endif
@@ -327,7 +331,7 @@
                             id="{{ $field['id'] }}"
                             name="{{ $field['id'] }}"
                             value="{{ old($field['id'], optional($inmueble)->{$field['id']}) }}"
-                            class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            class="{{ $formControlClasses }}"
                         >
                         @error($field['id'])
                             <p class="text-sm text-red-400">{{ $message }}</p>
@@ -337,30 +341,30 @@
             </div>
 
             <div class="grid gap-5 lg:grid-cols-2">
-                <div class="space-y-2">
-                    <label for="video_url" class="text-sm font-medium">Video del inmueble</label>
+                <div class="space-y-3">
+                    <label for="video_url" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Video del inmueble</label>
                     <input
                         type="url"
                         id="video_url"
                         name="video_url"
                         value="{{ old('video_url', optional($inmueble)->video_url) }}"
                         placeholder="https://www.youtube.com/..."
-                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        class="{{ $formControlClasses }}"
                     >
                     @error('video_url')
                         <p class="text-sm text-red-400">{{ $message }}</p>
                     @enderror
                 </div>
 
-                <div class="space-y-2">
-                    <label for="tour_virtual_url" class="text-sm font-medium">Tour virtual</label>
+                <div class="space-y-3">
+                    <label for="tour_virtual_url" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Tour virtual</label>
                     <input
                         type="url"
                         id="tour_virtual_url"
                         name="tour_virtual_url"
                         value="{{ old('tour_virtual_url', optional($inmueble)->tour_virtual_url) }}"
                         placeholder="https://my.matterport.com/..."
-                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        class="{{ $formControlClasses }}"
                     >
                     @error('tour_virtual_url')
                         <p class="text-sm text-red-400">{{ $message }}</p>
@@ -370,30 +374,30 @@
         </div>
     </section>
 
-    <section class="rounded-3xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/30">
+    <section class="rounded-3xl border border-white/5 bg-gradient-to-br from-gray-950/90 via-gray-900/70 to-gray-950/80 p-8 shadow-2xl shadow-black/40 backdrop-blur">
         <div class="grid gap-6 lg:grid-cols-2">
-            <div class="space-y-2">
-                <label for="amenidades" class="text-sm font-medium">Amenidades destacadas</label>
+            <div class="space-y-3">
+                <label for="amenidades" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Amenidades destacadas</label>
                 <textarea
                     id="amenidades"
                     name="amenidades"
                     rows="6"
                     placeholder="Escribe cada amenidad en una línea. Ej. Alberca\nRoof garden\nSeguridad 24/7"
-                    class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    class="{{ $textareaControlClasses }}"
                 >{{ $amenidadesText }}</textarea>
                 @error('amenidades')
                     <p class="text-sm text-red-400">{{ $message }}</p>
                 @enderror
             </div>
 
-            <div class="space-y-2">
-                <label for="extras" class="text-sm font-medium">Extras o notas internas</label>
+            <div class="space-y-3">
+                <label for="extras" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Extras o notas internas</label>
                 <textarea
                     id="extras"
                     name="extras"
                     rows="6"
                     placeholder="Ideal para registrar detalles logísticos o recordatorios para el equipo"
-                    class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    class="{{ $textareaControlClasses }}"
                 >{{ $extrasText }}</textarea>
                 @error('extras')
                     <p class="text-sm text-red-400">{{ $message }}</p>
@@ -402,10 +406,10 @@
         </div>
     </section>
 
-    <section class="rounded-3xl border border-gray-800 bg-gray-900/60 p-6 shadow-xl shadow-black/30">
+    <section class="rounded-3xl border border-white/5 bg-gradient-to-br from-gray-950/90 via-gray-900/70 to-gray-950/80 p-8 shadow-2xl shadow-black/40 backdrop-blur">
         <div class="space-y-4">
             <div>
-                <h2 class="text-lg font-semibold">Galería</h2>
+                <h2 class="text-lg font-semibold text-gray-100">Galería</h2>
                 <p class="text-sm text-gray-400">Sube hasta 10 fotografías en formato JPG o PNG. Las primeras se mostrarán como portada.</p>
             </div>
 
@@ -420,7 +424,7 @@
                     class="sr-only"
                 >
                 <div
-                    class="flex cursor-pointer flex-col gap-6 rounded-2xl border border-dashed border-gray-700 bg-gray-850/70 px-6 py-8 text-center transition focus:outline-none focus:ring-2 focus:ring-indigo-400/40 focus:ring-offset-2 focus:ring-offset-gray-950 hover:border-indigo-400/60 hover:bg-gray-850/80"
+                    class="flex cursor-pointer flex-col gap-6 rounded-2xl border border-dashed border-gray-700/70 bg-gray-900/60 px-6 py-8 text-center transition duration-200 hover:border-indigo-400/70 hover:bg-gray-900/70 focus:outline-none focus:ring-2 focus:ring-indigo-400/50 focus:ring-offset-2 focus:ring-offset-gray-950"
                     data-gallery-dropzone
                     role="button"
                     tabindex="0"
@@ -428,12 +432,12 @@
                     aria-label="Agregar imágenes a la galería"
                 >
                     <div class="flex flex-col items-center justify-center gap-4" data-gallery-empty-state>
-                        <div class="flex h-12 w-12 items-center justify-center rounded-full bg-gray-800/80 text-indigo-300">
+                        <div class="flex h-12 w-12 items-center justify-center rounded-full bg-gray-800/80 text-indigo-300 shadow-lg shadow-black/30">
                             <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5m-15 12.75h13.5A1.5 1.5 0 0 0 20.25 18V6a1.5 1.5 0 0 0-1.5-1.5H5.25A1.5 1.5 0 0 0 3.75 6v12a1.5 1.5 0 0 0 1.5 1.5Zm5.25-3.75h4.5a1.5 1.5 0 0 0 1.29-2.295l-2.25-3.75a1.5 1.5 0 0 0-2.58 0l-2.25 3.75A1.5 1.5 0 0 0 9 15.75Z" />
                             </svg>
                         </div>
-                        <p class="text-sm font-medium text-gray-100">Haz clic para seleccionar tus fotos</p>
+                        <p class="text-sm font-medium text-gray-200">Haz clic para seleccionar tus fotos</p>
                     </div>
                     <div class="hidden w-full space-y-3 text-left" data-gallery-previews-wrapper>
                         <p class="text-xs text-gray-400">Arrastra las fotos para cambiar el orden. La primera será la portada.</p>
@@ -444,7 +448,7 @@
                         >
                             <template data-gallery-preview-template>
                                 <div
-                                    class="group relative flex cursor-grab flex-col gap-3 rounded-xl border border-gray-800 bg-gray-900/70 p-3 shadow-lg shadow-black/30 transition hover:border-indigo-400/60"
+                                    class="group relative flex cursor-grab flex-col gap-3 rounded-xl border border-gray-800/70 bg-gray-900/70 p-3 shadow-lg shadow-black/30 transition duration-200 hover:border-indigo-400/70 hover:shadow-indigo-500/20"
                                     data-gallery-preview
                                 >
                                     <div class="absolute right-2 top-2 z-20 flex items-center gap-2">
@@ -456,7 +460,7 @@
                                         </span>
                                         <button
                                             type="button"
-                                            class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-black/80 text-sm text-red-200 shadow-lg shadow-black/40 transition hover:bg-black/80 hover:text-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black/40"
+                                            class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-black/80 text-sm text-red-200 shadow-lg shadow-black/40 transition duration-150 hover:bg-black/70 hover:text-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black/40"
                                             aria-label="Eliminar imagen"
                                             data-gallery-remove
                                         >
@@ -491,7 +495,7 @@
                     </div>
                     <button
                         type="button"
-                        class="inline-flex items-center gap-2 self-center rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-medium text-indigo-200 transition hover:bg-indigo-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+                        class="inline-flex items-center gap-2 self-center rounded-full bg-indigo-500/15 px-4 py-1.5 text-xs font-semibold text-indigo-100 transition duration-200 hover:bg-indigo-500/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
                         data-gallery-add-more
                         aria-disabled="false"
                     >
@@ -513,7 +517,7 @@
             @if ($inmueble && $inmueble->images->isNotEmpty())
                 <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                     @foreach ($inmueble->images as $imagen)
-                        <label class="group relative block overflow-hidden rounded-2xl border border-gray-800 bg-gray-900/80 shadow-lg shadow-black/30">
+                        <label class="group relative block overflow-hidden rounded-2xl border border-gray-800/70 bg-gray-900/80 shadow-lg shadow-black/30 transition duration-200 hover:border-indigo-400/70">
                             <input type="checkbox" name="imagenes_eliminar[]" value="{{ $imagen->id }}" class="absolute right-3 top-3 h-4 w-4 rounded border-gray-600 bg-gray-800 text-red-500 focus:ring-red-400">
                             <img src="{{ $imagen->temporaryVariantUrl('watermarked') ?? $imagen->url }}" alt="Imagen inmueble" class="h-48 w-full object-cover transition duration-300 group-hover:scale-105">
                             <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-3 text-sm text-gray-200">


### PR DESCRIPTION
## Summary
- improve the inmueble form layout with gradient cards, refined spacing, and updated typography
- centralize reusable control styles to keep inputs, selects, and textareas visually consistent
- refresh the gallery dropzone and preview states with softer hover and focus feedback

## Testing
- no tests were run (per request)


------
https://chatgpt.com/codex/tasks/task_e_68d781c005a08323b6efd559b3a5bb82