### PR TITLE
Wrap postal selectors in grouped container for address form

### DIFF
--- a/resources/views/components/inmuebles/form.blade.php
+++ b/resources/views/components/inmuebles/form.blade.php
@@ -67,137 +67,143 @@
             </div>
 
             <!-- Dirección -->
-<div class="grid gap-6 lg:grid-cols-12">
-    <div class="space-y-3 lg:col-span-12">
-        <label for="direccion" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Dirección *</label>
-        <input
-            type="text"
-            id="direccion"
-            name="direccion"
-            value="{{ old('direccion', optional($inmueble)->direccion) }}"
-            placeholder="Calle y número"
-            class="{{ $formControlClasses }}"
-            required
-        >
-        @error('direccion')
-            <p class="text-sm text-red-400">{{ $message }}</p>
-        @enderror
-    </div>
-</div>
+            <div class="grid gap-6 lg:grid-cols-12">
+                <div class="space-y-3 lg:col-span-12">
+                    <label for="direccion" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Dirección *</label>
+                    <input
+                        type="text"
+                        id="direccion"
+                        name="direccion"
+                        value="{{ old('direccion', optional($inmueble)->direccion) }}"
+                        placeholder="Calle y número"
+                        class="{{ $formControlClasses }}"
+                        required
+                    >
+                    @error('direccion')
+                        <p class="text-sm text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+            </div>
 
-<!-- C.P. + Colonia -->
-<div class="grid gap-6 lg:grid-cols-12">
-    <div class="space-y-3 lg:col-span-6">
-        <label for="codigo_postal" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">C.P.</label>
-        <div class="space-y-2" data-searchable-select>
-            <input
-                type="search"
-                id="codigo-postal-search"
-                data-search-input
-                placeholder="Buscar C.P."
-                class="{{ $formControlClasses }}"
-                autocomplete="off"
+            <!-- C.P. + Colonia -->
+            <section
+                class="space-y-6"
+                data-postal-selector
+                data-postal-options-url="{{ route('codigos-postales.index') }}"
             >
-            <select
-                id="codigo_postal"
-                name="codigo_postal"
-                class="{{ $selectControlClasses }}"
-            >
-                <option value="">Selecciona una opción</option>
-                @if ($selectedCodigoPostal)
-                    <option value="{{ $selectedCodigoPostal }}" selected>{{ $selectedCodigoPostal }}</option>
-                @endif
-            </select>
-        </div>
-        @error('codigo_postal')
-            <p class="text-sm text-red-400">{{ $message }}</p>
-        @enderror
-    </div>
+                <div class="grid gap-6 lg:grid-cols-12">
+                    <div class="space-y-3 lg:col-span-6">
+                        <label for="codigo_postal" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">C.P.</label>
+                        <div class="space-y-2" data-searchable-select>
+                            <input
+                                type="search"
+                                id="codigo-postal-search"
+                                data-search-input
+                                placeholder="Buscar C.P."
+                                class="{{ $formControlClasses }}"
+                                autocomplete="off"
+                            >
+                            <select
+                                id="codigo_postal"
+                                name="codigo_postal"
+                                class="{{ $selectControlClasses }}"
+                            >
+                                <option value="">Selecciona una opción</option>
+                                @if ($selectedCodigoPostal)
+                                    <option value="{{ $selectedCodigoPostal }}" selected>{{ $selectedCodigoPostal }}</option>
+                                @endif
+                            </select>
+                        </div>
+                        @error('codigo_postal')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
 
-    <div class="space-y-3 lg:col-span-6">
-        <label for="colonia" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Colonia</label>
-        <div class="space-y-2" data-searchable-select>
-            <input
-                type="search"
-                id="colonia-search"
-                data-search-input
-                placeholder="Buscar colonia"
-                class="{{ $formControlClasses }}"
-                autocomplete="off"
-            >
-            <select
-                id="colonia"
-                name="colonia"
-                class="{{ $selectControlClasses }}"
-            >
-                <option value="">Selecciona una opción</option>
-                @if ($selectedColonia)
-                    <option value="{{ $selectedColonia }}" selected>{{ $selectedColonia }}</option>
-                @endif
-            </select>
-        </div>
-        @error('colonia')
-            <p class="text-sm text-red-400">{{ $message }}</p>
-        @enderror
-    </div>
-</div>
+                    <div class="space-y-3 lg:col-span-6">
+                        <label for="colonia" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Colonia</label>
+                        <div class="space-y-2" data-searchable-select>
+                            <input
+                                type="search"
+                                id="colonia-search"
+                                data-search-input
+                                placeholder="Buscar colonia"
+                                class="{{ $formControlClasses }}"
+                                autocomplete="off"
+                            >
+                            <select
+                                id="colonia"
+                                name="colonia"
+                                class="{{ $selectControlClasses }}"
+                            >
+                                <option value="">Selecciona una opción</option>
+                                @if ($selectedColonia)
+                                    <option value="{{ $selectedColonia }}" selected>{{ $selectedColonia }}</option>
+                                @endif
+                            </select>
+                        </div>
+                        @error('colonia')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+                </div>
 
-<!-- Municipio + Estado -->
-<div class="grid gap-6 lg:grid-cols-12">
-    <div class="space-y-3 lg:col-span-6">
-        <label for="municipio" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Municipio</label>
-        <div class="space-y-2" data-searchable-select>
-            <input
-                type="search"
-                id="municipio-search"
-                data-search-input
-                placeholder="Buscar municipio"
-                class="{{ $formControlClasses }}"
-                autocomplete="off"
-            >
-            <select
-                id="municipio"
-                name="municipio"
-                class="{{ $selectControlClasses }}"
-            >
-                <option value="">Selecciona una opción</option>
-                @if ($selectedMunicipio)
-                    <option value="{{ $selectedMunicipio }}" selected>{{ $selectedMunicipio }}</option>
-                @endif
-            </select>
-        </div>
-        @error('municipio')
-            <p class="text-sm text-red-400">{{ $message }}</p>
-        @enderror
-    </div>
+                <!-- Municipio + Estado -->
+                <div class="grid gap-6 lg:grid-cols-12">
+                    <div class="space-y-3 lg:col-span-6">
+                        <label for="municipio" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Municipio</label>
+                        <div class="space-y-2" data-searchable-select>
+                            <input
+                                type="search"
+                                id="municipio-search"
+                                data-search-input
+                                placeholder="Buscar municipio"
+                                class="{{ $formControlClasses }}"
+                                autocomplete="off"
+                            >
+                            <select
+                                id="municipio"
+                                name="municipio"
+                                class="{{ $selectControlClasses }}"
+                            >
+                                <option value="">Selecciona una opción</option>
+                                @if ($selectedMunicipio)
+                                    <option value="{{ $selectedMunicipio }}" selected>{{ $selectedMunicipio }}</option>
+                                @endif
+                            </select>
+                        </div>
+                        @error('municipio')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
 
-    <div class="space-y-3 lg:col-span-6">
-        <label for="estado" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Estado</label>
-        <div class="space-y-2" data-searchable-select>
-            <input
-                type="search"
-                id="estado-search"
-                data-search-input
-                placeholder="Buscar estado"
-                class="{{ $formControlClasses }}"
-                autocomplete="off"
-            >
-            <select
-                id="estado"
-                name="estado"
-                class="{{ $selectControlClasses }}"
-            >
-                <option value="">Selecciona una opción</option>
-                @if ($selectedEstado)
-                    <option value="{{ $selectedEstado }}" selected>{{ $selectedEstado }}</option>
-                @endif
-            </select>
-        </div>
-        @error('estado')
-            <p class="text-sm text-red-400">{{ $message }}</p>
-        @enderror
-    </div>
-</div>
+                    <div class="space-y-3 lg:col-span-6">
+                        <label for="estado" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Estado</label>
+                        <div class="space-y-2" data-searchable-select>
+                            <input
+                                type="search"
+                                id="estado-search"
+                                data-search-input
+                                placeholder="Buscar estado"
+                                class="{{ $formControlClasses }}"
+                                autocomplete="off"
+                            >
+                            <select
+                                id="estado"
+                                name="estado"
+                                class="{{ $selectControlClasses }}"
+                            >
+                                <option value="">Selecciona una opción</option>
+                                @if ($selectedEstado)
+                                    <option value="{{ $selectedEstado }}" selected>{{ $selectedEstado }}</option>
+                                @endif
+                            </select>
+                        </div>
+                        @error('estado')
+                            <p class="text-sm text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+                </div>
+            </section>
 
            
             <div class="grid gap-5 {{ $showStatusSelector ? 'lg:grid-cols-3' : 'lg:grid-cols-2' }}">


### PR DESCRIPTION
## Summary
- wrap the postal-related selects in a dedicated section that groups the address fields
- expose data attributes for the postal selector to load options via the codigos-postales route

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7869c5a1c8323a8147a451cce38d1