### PR TITLE
Handle postal selector search on Enter key

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -521,7 +521,14 @@ document.addEventListener("DOMContentLoaded", () => {
                 };
 
                 searchable.searchInput.addEventListener("focus", triggerFetch);
-                searchable.searchInput.addEventListener("input", triggerFetch);
+                searchable.searchInput.addEventListener("keydown", (event) => {
+                    if (event.key !== "Enter") {
+                        return;
+                    }
+
+                    event.preventDefault();
+                    triggerFetch();
+                });
             }
         });
 


### PR DESCRIPTION
## Summary
- update the postal selector search input to trigger remote lookups only when pressing Enter

## Testing
- npm run build *(fails: Can't resolve '../../vendor/livewire/flux/dist/flux.css')*


------
https://chatgpt.com/codex/tasks/task_e_68d7928cd1708323bd56347f3edae8da