### PR TITLE
Auto-select first postal option after search

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -294,7 +294,11 @@ document.addEventListener("DOMContentLoaded", () => {
         const repopulateField = (
             key,
             values,
-            { triggered = false, autoSelectSingle = false } = {}
+            {
+                triggered = false,
+                autoSelectSingle = false,
+                autoSelectFirst = false,
+            } = {}
         ) => {
             const field = fields[key];
 
@@ -325,6 +329,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
             if (!normalizedValues.includes(previousValue)) {
                 if (autoSelectSingle && normalizedValues.length === 1) {
+                    newValue = normalizedValues[0];
+                } else if (autoSelectFirst && normalizedValues.length > 0) {
                     newValue = normalizedValues[0];
                 } else {
                     newValue = "";
@@ -412,7 +418,16 @@ document.addEventListener("DOMContentLoaded", () => {
                     return;
                 }
 
-                repopulateField(type, values, { triggered: true });
+                const { changed, newValue } = repopulateField(type, values, {
+                    triggered: true,
+                    autoSelectFirst: true,
+                });
+
+                if (changed && newValue) {
+                    fields[type]?.select.dispatchEvent(
+                        new Event("change", { bubbles: true })
+                    );
+                }
             } catch (error) {
                 console.error(
                     "No fue posible obtener las opciones de códigos postales.",


### PR DESCRIPTION
## Summary
- add support for automatically picking the first option returned by postal searches
- trigger the select change event so dependent postal fields refresh in sync

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d795bcf6548323a359ca0c9d69d4bd