### PR TITLE
Revert auto-select behavior for postal selectors

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -294,11 +294,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const repopulateField = (
             key,
             values,
-            {
-                triggered = false,
-                autoSelectSingle = false,
-                autoSelectFirst = false,
-            } = {}
+            { triggered = false, autoSelectSingle = false } = {}
         ) => {
             const field = fields[key];
 
@@ -329,8 +325,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
             if (!normalizedValues.includes(previousValue)) {
                 if (autoSelectSingle && normalizedValues.length === 1) {
-                    newValue = normalizedValues[0];
-                } else if (autoSelectFirst && normalizedValues.length > 0) {
                     newValue = normalizedValues[0];
                 } else {
                     newValue = "";
@@ -418,16 +412,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     return;
                 }
 
-                const { changed, newValue } = repopulateField(type, values, {
-                    triggered: true,
-                    autoSelectFirst: true,
-                });
-
-                if (changed && newValue) {
-                    fields[type]?.select.dispatchEvent(
-                        new Event("change", { bubbles: true })
-                    );
-                }
+                repopulateField(type, values, { triggered: true });
             } catch (error) {
                 console.error(
                     "No fue posible obtener las opciones de códigos postales.",


### PR DESCRIPTION
## Summary
- remove the autoSelectFirst option from repopulateField and restore the previous behavior
- stop automatically selecting the first postal search result when updating options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d798b93c6c8323a4083387e9485828