### PR TITLE
Integrate Choices for searchable select fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
                 "autoprefixer": "^10.4.20",
                 "axios": "^1.7.4",
                 "chart.js": "^4.5.0",
+                "choices.js": "file:resources/js/vendor/choices",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^2.0",
                 "tailwindcss": "^4.0.7",
@@ -1212,6 +1213,10 @@
             "engines": {
                 "pnpm": ">=8"
             }
+        },
+        "node_modules/choices.js": {
+            "resolved": "resources/js/vendor/choices",
+            "link": true
         },
         "node_modules/chownr": {
             "version": "3.0.0",
@@ -2460,6 +2465,10 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "resources/js/vendor/choices": {
+            "name": "choices.js",
+            "version": "0.0.1"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.4",
+        "choices.js": "file:resources/js/vendor/choices",
         "chart.js": "^4.5.0",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.0",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -65,16 +65,6 @@ select:focus[data-flux-control] {
     @apply size-4;
 } */
 
-[data-searchable-select] select {
-    background-color: #1f2937;
-    color: #f9fafb;
-}
-
-[data-searchable-select] select option {
-    background-color: #111827;
-    color: #f9fafb;
-}
-
 select.bg-gray-850\/70 {
     background-color: rgba(17, 24, 39, 0.7);
     color: #f9fafb;

--- a/resources/js/vendor/choices/index.js
+++ b/resources/js/vendor/choices/index.js
@@ -1,0 +1,286 @@
+const defaultClassNames = {
+    container: "choices",
+    containerOpen: "choices--open",
+    containerDisabled: "choices--disabled",
+    input: "choices__search",
+    select: "choices__select",
+};
+
+const toArray = (value) => {
+    if (!value) {
+        return [];
+    }
+
+    return Array.isArray(value) ? value : [value];
+};
+
+export default class Choices {
+    constructor(element, options = {}) {
+        if (!element || element.nodeName !== "SELECT") {
+            throw new TypeError("Choices requiere un elemento <select> válido");
+        }
+
+        this.select = element;
+        this.config = {
+            searchEnabled: true,
+            searchPlaceholderValue: "Buscar...",
+            classNames: {},
+            ...options,
+        };
+
+        this.classNames = {
+            ...defaultClassNames,
+            ...(this.config.classNames || {}),
+        };
+
+        this.container = this._resolveContainer();
+        this.container.classList.add(this.classNames.container);
+        this.select.classList.add(this.classNames.select);
+
+        this.searchInput = this._createSearchInput();
+        this.suppressChangeEvent = false;
+        this.isDestroyed = false;
+
+        this._bindEvents();
+        this._observeMutations();
+        this.refresh({ resetSearch: true, dispatchChange: false });
+    }
+
+    _resolveContainer() {
+        const container = this.select.closest("[data-searchable-select]");
+
+        if (container) {
+            return container;
+        }
+
+        const wrapper = document.createElement("div");
+        wrapper.dataset.searchableSelect = "";
+        this.select.parentNode?.insertBefore(wrapper, this.select);
+        wrapper.appendChild(this.select);
+
+        return wrapper;
+    }
+
+    _createSearchInput() {
+        if (!this.config.searchEnabled) {
+            return null;
+        }
+
+        const input = document.createElement("input");
+        input.type = "search";
+        input.autocomplete = "off";
+        input.placeholder = this.config.searchPlaceholderValue || "Buscar...";
+        input.className = this.classNames.input;
+
+        this.container.insertBefore(input, this.select);
+
+        return input;
+    }
+
+    _bindEvents() {
+        if (!this.searchInput) {
+            return;
+        }
+
+        this._handleInput = () => {
+            this.filter();
+        };
+
+        this._handleSearch = () => {
+            this.filter();
+        };
+
+        this._handleKeydown = (event) => {
+            if (event.key !== "Enter") {
+                return;
+            }
+
+            event.preventDefault();
+
+            const firstVisibleOption = this._getOptions().find((option) => {
+                return !option.hidden && option.value !== "";
+            });
+
+            if (!firstVisibleOption) {
+                return;
+            }
+
+            this.setChoiceByValue(firstVisibleOption.value);
+        };
+
+        this._handleBlur = () => {
+            if (!this.searchInput) {
+                return;
+            }
+
+            if (this.searchInput.value.trim() !== "") {
+                return;
+            }
+
+            this._getOptions().forEach((option) => {
+                option.hidden = false;
+            });
+        };
+
+        this.searchInput.addEventListener("input", this._handleInput);
+        this.searchInput.addEventListener("search", this._handleSearch);
+        this.searchInput.addEventListener("keydown", this._handleKeydown);
+        this.searchInput.addEventListener("blur", this._handleBlur);
+    }
+
+    _observeMutations() {
+        this._mutationObserver = new MutationObserver(() => {
+            this.refresh({ resetSearch: true, dispatchChange: false });
+        });
+
+        this._mutationObserver.observe(this.select, { childList: true });
+    }
+
+    _getOptions() {
+        return Array.from(this.select.options);
+    }
+
+    filter() {
+        if (!this.searchInput) {
+            return;
+        }
+
+        const term = this.searchInput.value.trim().toLowerCase();
+        const options = this._getOptions();
+
+        options.forEach((option) => {
+            if (option.value === "") {
+                option.hidden = false;
+                return;
+            }
+
+            const source = option.dataset.searchable || option.textContent || "";
+            const matches = term === "" || source.toLowerCase().includes(term);
+
+            option.hidden = !matches;
+        });
+
+        const selectedOption = this.select.selectedOptions[0];
+
+        if (!selectedOption || !selectedOption.hidden) {
+            return;
+        }
+
+        this._setValue("", { dispatchChange: true });
+    }
+
+    refresh({ resetSearch = true, dispatchChange = true } = {}) {
+        if (this.isDestroyed) {
+            return;
+        }
+
+        const previousValue = this.select.value;
+        const previousSuppressState = this.suppressChangeEvent;
+
+        this.suppressChangeEvent = !dispatchChange;
+
+        if (resetSearch && this.searchInput) {
+            this.searchInput.value = "";
+        }
+
+        this._getOptions().forEach((option) => {
+            option.hidden = false;
+        });
+
+        if (this.searchInput) {
+            this.filter();
+        }
+
+        this.suppressChangeEvent = previousSuppressState;
+
+        if (dispatchChange && previousValue !== this.select.value) {
+            this.select.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+    }
+
+    clearChoices() {
+        this.select.innerHTML = "";
+        this.refresh({ resetSearch: true, dispatchChange: false });
+    }
+
+    setChoices(items, valueKey = "value", labelKey = "label", replaceChoices = false) {
+        const choices = toArray(items);
+
+        if (replaceChoices) {
+            this.clearChoices();
+        }
+
+        const fragment = document.createDocumentFragment();
+
+        choices.forEach((item) => {
+            const value = item?.[valueKey];
+            const label = item?.[labelKey];
+
+            if (value === undefined || value === null) {
+                return;
+            }
+
+            const option = document.createElement("option");
+            option.value = String(value);
+            option.textContent = label === undefined ? String(value) : String(label);
+
+            if (item && item.selected) {
+                option.selected = true;
+            }
+
+            if (item && item.disabled) {
+                option.disabled = true;
+            }
+
+            fragment.appendChild(option);
+        });
+
+        this.select.appendChild(fragment);
+        this.refresh({ resetSearch: false, dispatchChange: false });
+    }
+
+    setChoiceByValue(value) {
+        this._setValue(value, { dispatchChange: true });
+    }
+
+    removeActiveItems() {
+        this._setValue("", { dispatchChange: true });
+    }
+
+    _setValue(value, { dispatchChange = true } = {}) {
+        const stringValue = value === undefined || value === null ? "" : String(value);
+        const previousValue = this.select.value;
+
+        this.select.value = stringValue;
+
+        if (!dispatchChange || previousValue === stringValue) {
+            return;
+        }
+
+        this.select.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+
+    destroy() {
+        if (this.isDestroyed) {
+            return;
+        }
+
+        if (this._mutationObserver) {
+            this._mutationObserver.disconnect();
+            this._mutationObserver = null;
+        }
+
+        if (this.searchInput) {
+            this.searchInput.removeEventListener("input", this._handleInput);
+            this.searchInput.removeEventListener("search", this._handleSearch);
+            this.searchInput.removeEventListener("keydown", this._handleKeydown);
+            this.searchInput.removeEventListener("blur", this._handleBlur);
+            this.searchInput.remove();
+        }
+
+        this.select.classList.remove(this.classNames.select);
+        this.container.classList.remove(this.classNames.container);
+
+        this.isDestroyed = true;
+    }
+}

--- a/resources/js/vendor/choices/package.json
+++ b/resources/js/vendor/choices/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "choices.js",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "./index.js",
+  "module": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./styles.css": "./styles.css"
+  }
+}

--- a/resources/js/vendor/choices/styles.css
+++ b/resources/js/vendor/choices/styles.css
@@ -1,0 +1,36 @@
+.choices {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.choices__search {
+    display: block;
+    width: 100%;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(55, 65, 81, 0.7);
+    background-color: rgba(17, 24, 39, 0.6);
+    padding: 0.75rem 1rem;
+    color: #f9fafb;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.choices__search::placeholder {
+    color: rgba(156, 163, 175, 0.85);
+}
+
+.choices__search:focus {
+    outline: none;
+    border-color: rgba(99, 102, 241, 0.6);
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
+}
+
+.choices__select {
+    background-color: rgba(17, 24, 39, 0.7);
+    color: #f9fafb;
+}
+
+.choices__select option {
+    background-color: #111827;
+    color: #f9fafb;
+}

--- a/resources/views/components/inmuebles/form.blade.php
+++ b/resources/views/components/inmuebles/form.blade.php
@@ -94,15 +94,11 @@
                 <div class="grid gap-6 lg:grid-cols-12">
                     <div class="space-y-3 lg:col-span-6">
                         <label for="codigo_postal" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">C.P.</label>
-                        <div class="space-y-2" data-searchable-select>
-                            <input
-                                type="search"
-                                id="codigo-postal-search"
-                                data-search-input
-                                placeholder="Buscar C.P."
-                                class="{{ $formControlClasses }}"
-                                autocomplete="off"
-                            >
+                        <div
+                            class="space-y-2"
+                            data-searchable-select
+                            data-search-placeholder="Buscar C.P."
+                        >
                             <select
                                 id="codigo_postal"
                                 name="codigo_postal"
@@ -121,15 +117,11 @@
 
                     <div class="space-y-3 lg:col-span-6">
                         <label for="colonia" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Colonia</label>
-                        <div class="space-y-2" data-searchable-select>
-                            <input
-                                type="search"
-                                id="colonia-search"
-                                data-search-input
-                                placeholder="Buscar colonia"
-                                class="{{ $formControlClasses }}"
-                                autocomplete="off"
-                            >
+                        <div
+                            class="space-y-2"
+                            data-searchable-select
+                            data-search-placeholder="Buscar colonia"
+                        >
                             <select
                                 id="colonia"
                                 name="colonia"
@@ -151,15 +143,11 @@
                 <div class="grid gap-6 lg:grid-cols-12">
                     <div class="space-y-3 lg:col-span-6">
                         <label for="municipio" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Municipio</label>
-                        <div class="space-y-2" data-searchable-select>
-                            <input
-                                type="search"
-                                id="municipio-search"
-                                data-search-input
-                                placeholder="Buscar municipio"
-                                class="{{ $formControlClasses }}"
-                                autocomplete="off"
-                            >
+                        <div
+                            class="space-y-2"
+                            data-searchable-select
+                            data-search-placeholder="Buscar municipio"
+                        >
                             <select
                                 id="municipio"
                                 name="municipio"
@@ -178,15 +166,11 @@
 
                     <div class="space-y-3 lg:col-span-6">
                         <label for="estado" class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Estado</label>
-                        <div class="space-y-2" data-searchable-select>
-                            <input
-                                type="search"
-                                id="estado-search"
-                                data-search-input
-                                placeholder="Buscar estado"
-                                class="{{ $formControlClasses }}"
-                                autocomplete="off"
-                            >
+                        <div
+                            class="space-y-2"
+                            data-searchable-select
+                            data-search-placeholder="Buscar estado"
+                        >
                             <select
                                 id="estado"
                                 name="estado"

--- a/resources/views/contacts/create.blade.php
+++ b/resources/views/contacts/create.blade.php
@@ -68,15 +68,11 @@
 
                     <div class="space-y-2">
                         <label for="inmueble_id" class="block text-sm font-medium text-gray-300">Inmueble de interés</label>
-                        <div class="space-y-2" data-searchable-select>
-                            <input
-                                type="search"
-                                id="inmueble-search"
-                                data-search-input
-                                placeholder="Buscar por título o dirección"
-                                class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                                autocomplete="off"
-                            >
+                        <div
+                            class="space-y-2"
+                            data-searchable-select
+                            data-search-placeholder="Buscar por título o dirección"
+                        >
                             <select
                                 id="inmueble_id"
                                 name="inmueble_id"

--- a/resources/views/contacts/show.blade.php
+++ b/resources/views/contacts/show.blade.php
@@ -89,16 +89,12 @@
                             data-swal-loader="registrar-interes"
                         >
                             @csrf
-                            <div class="space-y-2" data-searchable-select>
+                            <div
+                                class="space-y-2"
+                                data-searchable-select
+                                data-search-placeholder="Buscar por título o dirección"
+                            >
                                 <label for="nuevo-inmueble" class="block text-sm font-medium text-gray-300">Agregar inmueble</label>
-                                <input
-                                    type="search"
-                                    id="nuevo-inmueble-buscar"
-                                    data-search-input
-                                    placeholder="Buscar por título o dirección"
-                                    class="w-full rounded-xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                                    autocomplete="off"
-                                >
                                 <select
                                     id="nuevo-inmueble"
                                     name="inmueble_id"


### PR DESCRIPTION
## Summary
- add a local Choices.js package and styles so searchable selects can be powered by a reusable component
- replace the bespoke filtering helper with Choices instances in `app.js` and adapt postal selector logic to refresh through the new API
- simplify Blade forms by removing manual search inputs while wiring placeholders for the auto-generated Choice inputs

## Testing
- `npm run build` *(fails: vendor/livewire/flux/dist/flux.css missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a43ab0608323b8e490f702059eed