### PR TITLE
Trigger postal selector fetch on search input events

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -422,6 +422,8 @@ document.addEventListener("DOMContentLoaded", () => {
                 };
 
                 choices.searchInput.addEventListener("focus", triggerFetch);
+                choices.searchInput.addEventListener("input", triggerFetch);
+                choices.searchInput.addEventListener("search", triggerFetch);
                 choices.searchInput.addEventListener("keydown", (event) => {
                     if (event.key !== "Enter") {
                         return;


### PR DESCRIPTION
## Summary
- trigger the postal selector debounce fetch when users type or search in the Choices inputs
- ensure postal suggestions refresh without requiring the Enter key

## Testing
- npm run build *(fails: Can't resolve '../../vendor/livewire/flux/dist/flux.css')*

------
https://chatgpt.com/codex/tasks/task_e_68d7a88b3dcc8323ab46aed8ad056e07