### PR TITLE
Fix Leaflet marker asset URLs

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,9 +5,18 @@ import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import "leaflet-control-geocoder/dist/Control.Geocoder.css";
 import "leaflet-control-geocoder";
-import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
-import markerIcon from "leaflet/dist/images/marker-icon.png";
-import markerShadow from "leaflet/dist/images/marker-shadow.png";
+const markerIcon2x = new URL(
+    "leaflet/dist/images/marker-icon-2x.png",
+    import.meta.url
+).href;
+const markerIcon = new URL(
+    "leaflet/dist/images/marker-icon.png",
+    import.meta.url
+).href;
+const markerShadow = new URL(
+    "leaflet/dist/images/marker-shadow.png",
+    import.meta.url
+).href;
 
 L.Icon.Default.mergeOptions({
     iconRetinaUrl: markerIcon2x,


### PR DESCRIPTION
## Summary
- resolve Leaflet marker asset URLs using import.meta.url so the built bundle emits valid paths
- keep the default icon merge using the resolved retina, base, and shadow URLs

## Testing
- npm run build *(fails: Can't resolve '../../vendor/livewire/flux/dist/flux.css')*

------
https://chatgpt.com/codex/tasks/task_e_68d8939f39508323bf8bed4f76e2a1e2