### PR TITLE
Fix Leaflet marker image path

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -13,6 +13,7 @@ L.Icon.Default.mergeOptions({
     iconRetinaUrl: markerIcon2x,
     iconUrl: markerIcon,
     shadowUrl: markerShadow,
+    imagePath: "",
 });
 
 document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary
- set Leaflet's default icon imagePath to an empty string so Vite resolves assets correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89a7311d483238d9e89652213f643