### PR TITLE
Fix Leaflet default icon configuration

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -9,11 +9,12 @@ import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
 import markerIcon from "leaflet/dist/images/marker-icon.png";
 import markerShadow from "leaflet/dist/images/marker-shadow.png";
 
+delete L.Icon.Default.prototype._getIconUrl;
+
 L.Icon.Default.mergeOptions({
     iconRetinaUrl: markerIcon2x,
     iconUrl: markerIcon,
     shadowUrl: markerShadow,
-    imagePath: "",
 });
 
 document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary
- prevent Leaflet from using the default icon URL resolution helper so that Vite can inject asset URLs
- remove the unused imagePath override from the default icon configuration

## Testing
- npm run build *(fails: Can't resolve '../../vendor/livewire/flux/dist/flux.css')*

------
https://chatgpt.com/codex/tasks/task_e_68d8a07dd73883239186b3b020e27dcb