### PR TITLE
Add admin property map view

### DIFF
--- a/app/Http/Controllers/InmuebleController.php
+++ b/app/Http/Controllers/InmuebleController.php
@@ -80,6 +80,38 @@ class InmuebleController extends Controller
     }
 
     /**
+     * Display the properties map view.
+     */
+    public function map(): View
+    {
+        $properties = Inmueble::query()
+            ->whereNotNull('latitud')
+            ->whereNotNull('longitud')
+            ->with('coverImage')
+            ->get()
+            ->map(function (Inmueble $inmueble): array {
+                $coverImage = $inmueble->coverImage;
+                $imageUrl = $coverImage?->temporaryVariantUrl('watermarked') ?? $coverImage?->url;
+
+                return [
+                    'id' => $inmueble->id,
+                    'title' => $inmueble->titulo,
+                    'latitude' => (float) $inmueble->latitud,
+                    'longitude' => (float) $inmueble->longitud,
+                    'address' => $inmueble->direccion,
+                    'price' => $inmueble->formattedPrice(),
+                    'image_url' => $imageUrl,
+                    'manage_url' => route('inmuebles.edit', $inmueble),
+                ];
+            })
+            ->values();
+
+        return view('inmuebles.map', [
+            'properties' => $properties,
+        ]);
+    }
+
+    /**
      * Show the form for creating a new property.
      */
     public function create(): View

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -14,6 +14,7 @@
             <flux:navlist variant="outline">
                 <flux:navlist.group :heading="__('Platform')" class="grid">
                     <flux:navlist.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>{{ __('Dashboard') }}</flux:navlist.item>
+                    <flux:navlist.item icon="map" :href="route('inmuebles.map')" :current="request()->routeIs('inmuebles.map')" wire:navigate>{{ __('Mapa de inmuebles') }}</flux:navlist.item>
                 </flux:navlist.group>
             </flux:navlist>
 

--- a/resources/views/inmuebles/map.blade.php
+++ b/resources/views/inmuebles/map.blade.php
@@ -1,0 +1,18 @@
+<x-layouts.admin title="Mapa de inmuebles">
+    <div class="space-y-6">
+        <header class="space-y-2">
+            <h1 class="text-3xl font-bold text-white">Mapa de inmuebles</h1>
+            <p class="text-sm text-gray-400">
+                Visualiza la ubicación de los inmuebles registrados y accede rápidamente a su edición.
+            </p>
+        </header>
+
+        <div
+            id="properties-map"
+            class="h-[600px] w-full overflow-hidden rounded-2xl border border-gray-800 bg-gray-950"
+            data-properties='@json($properties)'
+        ></div>
+    </div>
+
+    @vite('resources/js/app.js')
+</x-layouts.admin>

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,8 @@ Route::middleware(['auth'])->group(function () {
     Route::post('/contactos/{contact}/intereses', [ContactController::class, 'storeInterest'])
         ->name('contactos.intereses.store');
 
+    Route::get('/inmuebles/mapa', [InmuebleController::class, 'map'])
+        ->name('inmuebles.map');
     Route::resource('inmuebles', InmuebleController::class)->except(['show']);
 
     Route::prefix('catalogos')->name('catalogos.')->group(function () {


### PR DESCRIPTION
## Summary
- add an authenticated route and controller action that prepares inmueble data for a map view
- create the admin map blade view and expose serialized property data to the frontend
- extend the main JavaScript bundle to render Leaflet markers and expose the new map entry in the sidebar navigation

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d8d530ae088323a07ee147fd3ad874