### PR TITLE
Add property preview to contact creation form

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -56,12 +56,34 @@ class ContactController extends Controller
             ? $requestedField
             : $this->detectPrefillField($prefillValue);
 
+        $inmuebles = Inmueble::query()
+            ->with('coverImage')
+            ->orderBy('titulo')
+            ->get([
+                'id',
+                'titulo',
+                'direccion',
+                'operacion',
+                'tipo',
+                'colonia',
+                'municipio',
+                'estado',
+            ])
+            ->map(function (Inmueble $inmueble) {
+                $coverImage = $inmueble->coverImage;
+
+                $inmueble->setAttribute(
+                    'cover_image_url',
+                    $coverImage?->temporaryVariantUrl('watermarked') ?? $coverImage?->url
+                );
+
+                return $inmueble;
+            });
+
         return view('contacts.create', [
             'prefill' => $prefillValue,
             'prefillField' => $prefillField,
-            'inmuebles' => Inmueble::query()
-                ->orderBy('titulo')
-                ->get(['id', 'titulo', 'direccion', 'operacion', 'tipo']),
+            'inmuebles' => $inmuebles,
         ]);
     }
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -619,10 +619,60 @@ document.addEventListener("DOMContentLoaded", () => {
         return instance;
     };
 
+    const updateSearchableSelectPreview = (select) => {
+        if (!select) {
+            return;
+        }
+
+        const container = select.closest("[data-searchable-select]");
+
+        if (!container) {
+            return;
+        }
+
+        const preview = container.querySelector("[data-property-preview]");
+
+        if (!preview) {
+            return;
+        }
+
+        const placeholder = preview.dataset.placeholder || "";
+        const selectedOption = select.selectedOptions?.[0];
+        const coverImageUrl = selectedOption?.dataset?.coverImage;
+
+        if (coverImageUrl) {
+            preview.src = coverImageUrl;
+            preview.dataset.state = "filled";
+
+            return;
+        }
+
+        if (placeholder !== "") {
+            preview.src = placeholder;
+        } else {
+            preview.removeAttribute("src");
+        }
+
+        preview.dataset.state = "empty";
+    };
+
     document
         .querySelectorAll("[data-searchable-select] select")
         .forEach((select) => {
             initializeChoicesSelect(select);
+
+            if (select.__searchableSelectPreviewInitialized) {
+                updateSearchableSelectPreview(select);
+
+                return;
+            }
+
+            const handleChange = () => updateSearchableSelectPreview(select);
+
+            select.addEventListener("change", handleChange);
+            updateSearchableSelectPreview(select);
+
+            select.__searchableSelectPreviewInitialized = true;
         });
 
     const initializePostalSelector = (container) => {

--- a/resources/views/contacts/create.blade.php
+++ b/resources/views/contacts/create.blade.php
@@ -69,7 +69,7 @@
                     <div class="space-y-2">
                         <label for="inmueble_id" class="block text-sm font-medium text-gray-300">Inmueble de interés</label>
                         <div
-                            class="space-y-2"
+                            class="space-y-4"
                             data-searchable-select
                             data-search-placeholder="Buscar por título o dirección"
                         >
@@ -91,12 +91,20 @@
                                     <option
                                         value="{{ $inmueble->id }}"
                                         data-searchable="{{ Str::lower(trim($inmueble->titulo . ' ' . $fullAddress)) }}"
+                                        data-cover-image="{{ $inmueble->cover_image_url }}"
                                         @selected((string) old('inmueble_id') === (string) $inmueble->id)
                                     >
                                         {{ $inmueble->titulo }}@if ($fullAddress !== '') — {{ $fullAddress }}@endif
                                     </option>
                                 @endforeach
                             </select>
+                            <img
+                                data-property-preview
+                                data-placeholder="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+                                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+                                alt="Vista previa del inmueble seleccionado"
+                                class="h-40 w-full rounded-xl border border-gray-700 bg-gray-850 object-cover"
+                            >
                         </div>
                         <p class="text-sm text-gray-400">Utiliza el buscador para registrar el inmueble de interés que quedará ligado al historial.</p>
                         @error('inmueble_id')


### PR DESCRIPTION
## Summary
- eager load cover images when listing properties for new contacts and expose their URLs to Blade
- render a property preview container and store each cover image URL on the select options
- refresh the preview from JavaScript when the selection changes and rebuild the production assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8de05f1208323a9e9c7793d41904b