### PR TITLE
Enhance property preview for contact creation

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -68,6 +68,11 @@ class ContactController extends Controller
                 'colonia',
                 'municipio',
                 'estado',
+                'precio',
+                'habitaciones',
+                'banos',
+                'estacionamientos',
+                'metros_cuadrados',
             ])
             ->map(function (Inmueble $inmueble) {
                 $coverImage = $inmueble->coverImage;

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -630,30 +630,194 @@ document.addEventListener("DOMContentLoaded", () => {
             return;
         }
 
-        const preview = container.querySelector("[data-property-preview]");
+        const previewCard = container.querySelector("[data-property-preview]");
 
-        if (!preview) {
+        if (!previewCard) {
             return;
         }
 
-        const placeholder = preview.dataset.placeholder || "";
-        const selectedOption = select.selectedOptions?.[0];
-        const coverImageUrl = selectedOption?.dataset?.coverImage;
+        const imageElement = previewCard.querySelector(
+            "[data-property-preview-image]",
+        );
+        const titleElement = previewCard.querySelector(
+            "[data-property-preview-title]",
+        );
+        const addressElement = previewCard.querySelector(
+            "[data-property-preview-address]",
+        );
+        const operationElement = previewCard.querySelector(
+            "[data-property-preview-operation]",
+        );
+        const typeElement = previewCard.querySelector(
+            "[data-property-preview-type]",
+        );
+        const priceElement = previewCard.querySelector(
+            "[data-property-preview-price]",
+        );
+        const habitacionesElement = previewCard.querySelector(
+            "[data-property-preview-habitaciones]",
+        );
+        const banosElement = previewCard.querySelector(
+            "[data-property-preview-banos]",
+        );
+        const estacionamientosElement = previewCard.querySelector(
+            "[data-property-preview-estacionamientos]",
+        );
+        const metrosElement = previewCard.querySelector(
+            "[data-property-preview-metros]",
+        );
 
-        if (coverImageUrl) {
-            preview.src = coverImageUrl;
-            preview.dataset.state = "filled";
+        const selectedOption = select.value
+            ? select.selectedOptions?.[0] || null
+            : null;
+
+        const resetPreview = () => {
+            if (titleElement) {
+                titleElement.textContent = "";
+            }
+
+            if (addressElement) {
+                addressElement.textContent = "";
+            }
+
+            if (operationElement) {
+                operationElement.textContent = "";
+                operationElement.classList.add("hidden");
+            }
+
+            if (typeElement) {
+                typeElement.textContent = "";
+                typeElement.classList.add("hidden");
+            }
+
+            if (priceElement) {
+                priceElement.textContent = "";
+                priceElement.classList.add("hidden");
+            }
+
+            if (habitacionesElement) {
+                habitacionesElement.textContent = "";
+            }
+
+            if (banosElement) {
+                banosElement.textContent = "";
+            }
+
+            if (estacionamientosElement) {
+                estacionamientosElement.textContent = "";
+            }
+
+            if (metrosElement) {
+                metrosElement.textContent = "";
+            }
+
+            if (imageElement) {
+                const placeholder =
+                    imageElement.dataset.placeholder || "";
+
+                if (placeholder) {
+                    imageElement.src = placeholder;
+                } else {
+                    imageElement.removeAttribute("src");
+                }
+            }
+
+            previewCard.classList.add("hidden");
+            previewCard.classList.remove("flex");
+        };
+
+        if (!selectedOption || !selectedOption.value) {
+            resetPreview();
 
             return;
         }
 
-        if (placeholder !== "") {
-            preview.src = placeholder;
-        } else {
-            preview.removeAttribute("src");
+        const {
+            coverImage: coverImageUrl = "",
+            title = "",
+            fullAddress = "",
+            operation = "",
+            type = "",
+            price = "",
+            habitaciones = "",
+            banos = "",
+            estacionamientos = "",
+            metrosCuadrados = "",
+        } = selectedOption.dataset;
+
+        if (titleElement) {
+            titleElement.textContent = title || "";
         }
 
-        preview.dataset.state = "empty";
+        if (addressElement) {
+            addressElement.textContent = fullAddress || "";
+        }
+
+        if (operationElement) {
+            operationElement.textContent = operation || "";
+            operationElement.classList.toggle("hidden", !operation);
+        }
+
+        if (typeElement) {
+            typeElement.textContent = type || "";
+            typeElement.classList.toggle("hidden", !type);
+        }
+
+        if (priceElement) {
+            let formattedPrice = "";
+
+            if (price) {
+                const numericPrice = Number(price);
+
+                if (Number.isFinite(numericPrice)) {
+                    formattedPrice = new Intl.NumberFormat("es-MX", {
+                        style: "currency",
+                        currency: "MXN",
+                        maximumFractionDigits: 0,
+                    }).format(numericPrice);
+                } else {
+                    formattedPrice = price;
+                }
+            }
+
+            priceElement.textContent = formattedPrice;
+            priceElement.classList.toggle("hidden", !formattedPrice);
+        }
+
+        if (habitacionesElement) {
+            habitacionesElement.textContent = habitaciones || "-";
+        }
+
+        if (banosElement) {
+            banosElement.textContent = banos || "-";
+        }
+
+        if (estacionamientosElement) {
+            estacionamientosElement.textContent = estacionamientos || "-";
+        }
+
+        if (metrosElement) {
+            const formattedMetros = metrosCuadrados
+                ? `${metrosCuadrados} m²`
+                : "-";
+
+            metrosElement.textContent = formattedMetros;
+        }
+
+        if (imageElement) {
+            const placeholder = imageElement.dataset.placeholder || "";
+
+            if (coverImageUrl) {
+                imageElement.src = coverImageUrl;
+            } else if (placeholder) {
+                imageElement.src = placeholder;
+            } else {
+                imageElement.removeAttribute("src");
+            }
+        }
+
+        previewCard.classList.remove("hidden");
+        previewCard.classList.add("flex");
     };
 
     document

--- a/resources/views/contacts/create.blade.php
+++ b/resources/views/contacts/create.blade.php
@@ -92,19 +92,64 @@
                                         value="{{ $inmueble->id }}"
                                         data-searchable="{{ Str::lower(trim($inmueble->titulo . ' ' . $fullAddress)) }}"
                                         data-cover-image="{{ $inmueble->cover_image_url }}"
+                                        data-title="{{ $inmueble->titulo }}"
+                                        data-operation="{{ $inmueble->operacion }}"
+                                        data-type="{{ $inmueble->tipo }}"
+                                        data-full-address="{{ $fullAddress }}"
+                                        data-price="{{ $inmueble->precio }}"
+                                        data-habitaciones="{{ $inmueble->habitaciones }}"
+                                        data-banos="{{ $inmueble->banos }}"
+                                        data-estacionamientos="{{ $inmueble->estacionamientos }}"
+                                        data-metros-cuadrados="{{ $inmueble->metros_cuadrados }}"
                                         @selected((string) old('inmueble_id') === (string) $inmueble->id)
                                     >
                                         {{ $inmueble->titulo }}@if ($fullAddress !== '') — {{ $fullAddress }}@endif
                                     </option>
                                 @endforeach
                             </select>
-                            <img
+                            <div
                                 data-property-preview
-                                data-placeholder="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
-                                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
-                                alt="Vista previa del inmueble seleccionado"
-                                class="h-40 w-full rounded-xl border border-gray-700 bg-gray-850 object-cover"
+                                class="hidden flex-col gap-4 rounded-xl border border-gray-700 bg-gray-850/70 p-4"
                             >
+                                <div class="aspect-video w-full overflow-hidden rounded-lg border border-gray-800 bg-gray-900">
+                                    <img
+                                        data-property-preview-image
+                                        data-placeholder="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+                                        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+                                        alt="Vista previa del inmueble seleccionado"
+                                        class="h-full w-full object-cover"
+                                    >
+                                </div>
+                                <div class="space-y-3">
+                                    <div class="space-y-1">
+                                        <p data-property-preview-title class="text-lg font-semibold text-gray-100"></p>
+                                        <p data-property-preview-address class="text-sm text-gray-400"></p>
+                                    </div>
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <span data-property-preview-operation class="rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-medium text-indigo-300"></span>
+                                        <span data-property-preview-type class="rounded-full bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-300"></span>
+                                        <span data-property-preview-price class="ml-auto text-base font-semibold text-gray-100"></span>
+                                    </div>
+                                    <dl class="grid grid-cols-2 gap-3 text-sm text-gray-300">
+                                        <div>
+                                            <dt class="text-xs uppercase tracking-wide text-gray-500">Habitaciones</dt>
+                                            <dd data-property-preview-habitaciones class="font-semibold text-gray-100"></dd>
+                                        </div>
+                                        <div>
+                                            <dt class="text-xs uppercase tracking-wide text-gray-500">Baños</dt>
+                                            <dd data-property-preview-banos class="font-semibold text-gray-100"></dd>
+                                        </div>
+                                        <div>
+                                            <dt class="text-xs uppercase tracking-wide text-gray-500">Estacionamientos</dt>
+                                            <dd data-property-preview-estacionamientos class="font-semibold text-gray-100"></dd>
+                                        </div>
+                                        <div>
+                                            <dt class="text-xs uppercase tracking-wide text-gray-500">Metros cuadrados</dt>
+                                            <dd data-property-preview-metros class="font-semibold text-gray-100"></dd>
+                                        </div>
+                                    </dl>
+                                </div>
+                            </div>
                         </div>
                         <p class="text-sm text-gray-400">Utiliza el buscador para registrar el inmueble de interés que quedará ligado al historial.</p>
                         @error('inmueble_id')


### PR DESCRIPTION
## Summary
- include pricing and amenity fields when loading properties for the contact creation form
- add dataset metadata to property options and replace the preview image with a detailed card layout
- update the frontend script to hydrate the preview card based on the selected property and handle empty states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9f001fbb4832398e3e364aeffe459