### PR TITLE
Add commission capture when closing property status

### DIFF
--- a/resources/views/components/inmuebles/form.blade.php
+++ b/resources/views/components/inmuebles/form.blade.php
@@ -264,7 +264,11 @@
                         >
                             <option value="">Selecciona un estado</option>
                             @foreach ($statuses as $status)
-                                <option value="{{ $status->id }}" @selected((int) old('estatus_id', optional($inmueble)->estatus_id) === $status->id)>
+                                <option
+                                    value="{{ $status->id }}"
+                                    data-status-name="{{ $status->nombre }}"
+                                    @selected((int) old('estatus_id', optional($inmueble)->estatus_id) === $status->id)
+                                >
                                     {{ $status->nombre }}
                                 </option>
                             @endforeach
@@ -274,6 +278,31 @@
                         @enderror
                     </div>
                 @endif
+
+                <input
+                    type="hidden"
+                    id="commission_percentage"
+                    name="commission_percentage"
+                    value="{{ old('commission_percentage', optional($inmueble)->commission_percentage) }}"
+                >
+                <input
+                    type="hidden"
+                    id="commission_amount"
+                    name="commission_amount"
+                    value="{{ old('commission_amount', optional($inmueble)->commission_amount) }}"
+                >
+                <input
+                    type="hidden"
+                    id="commission_status_id"
+                    name="commission_status_id"
+                    value="{{ old('commission_status_id', optional($inmueble)->commission_status_id) }}"
+                >
+                <input
+                    type="hidden"
+                    id="commission_status_name"
+                    name="commission_status_name"
+                    value="{{ old('commission_status_name', optional($inmueble)->commission_status_name) }}"
+                >
             </div>
 
             <div class="space-y-3">


### PR DESCRIPTION
## Summary
- add hidden commission and status tracking inputs to the inmueble form
- prompt for commission percentage via SweetAlert2 when selecting closing statuses and persist the calculated amount
- keep commission totals in sync with the selected status and price field

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9f8ebe5ec83239b21d7811f676e4c