### PR TITLE
Handle commission requirements and log closed sales

### DIFF
--- a/app/Http/Requests/UpdateInmuebleRequest.php
+++ b/app/Http/Requests/UpdateInmuebleRequest.php
@@ -27,4 +27,15 @@ class UpdateInmuebleRequest extends StoreInmuebleRequest
 
         return $rules;
     }
+
+    protected function shouldRequireCommission(): bool
+    {
+        $statusId = $this->input('estatus_id');
+
+        if ($statusId === null || $statusId === '') {
+            $statusId = $this->route('inmueble')?->estatus_id;
+        }
+
+        return $this->shouldRequireCommissionForStatus($statusId);
+    }
 }

--- a/app/Models/Inmueble.php
+++ b/app/Models/Inmueble.php
@@ -58,6 +58,10 @@ class Inmueble extends Model
         'tour_virtual_url',
         'amenidades',
         'extras',
+        'commission_percentage',
+        'commission_amount',
+        'commission_status_id',
+        'commission_status_name',
     ];
 
     protected $casts = [
@@ -74,6 +78,9 @@ class Inmueble extends Model
         'longitud' => 'decimal:7',
         'amenidades' => 'array',
         'extras' => 'array',
+        'commission_percentage' => 'decimal:2',
+        'commission_amount' => 'decimal:2',
+        'commission_status_id' => 'integer',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];

--- a/app/Support/InmuebleStatusClassifier.php
+++ b/app/Support/InmuebleStatusClassifier.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\InmuebleStatus;
+use Illuminate\Support\Str;
+
+class InmuebleStatusClassifier
+{
+    /**
+     * Keywords that indicate a closing / finalized status.
+     *
+     * @var array<int, string>
+     */
+    private const CLOSING_KEYWORDS = [
+        'vendido',
+        'rentado',
+        'arrendado',
+        'cerrado',
+    ];
+
+    /**
+     * Cache of previously resolved closing status checks.
+     *
+     * @var array<int, bool>
+     */
+    private static array $closingStatusCache = [];
+
+    public static function isClosingStatusId(?int $statusId): bool
+    {
+        if (! $statusId) {
+            return false;
+        }
+
+        if (array_key_exists($statusId, self::$closingStatusCache)) {
+            return self::$closingStatusCache[$statusId];
+        }
+
+        $status = InmuebleStatus::query()->find($statusId);
+
+        return self::$closingStatusCache[$statusId] = self::isClosingStatusName($status?->nombre);
+    }
+
+    public static function isClosingStatusName(?string $name): bool
+    {
+        if ($name === null) {
+            return false;
+        }
+
+        $normalized = Str::of($name)
+            ->lower()
+            ->squish()
+            ->ascii()
+            ->value();
+
+        foreach (self::CLOSING_KEYWORDS as $keyword) {
+            if (Str::contains($normalized, $keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- validate commission fields when a closing status is selected using a shared status classifier
- compute commissions server-side on closing transitions and register the sale in the external ventasvillanuevagarcia table while avoiding duplicates
- persist commission metadata on the Inmueble model for subsequent access

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d9fa7929bc8323b0f4ede4b240da4b