### PR TITLE
Add AS DB connection configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,19 @@ DB_DATABASE=inmobiliaria
 DB_USERNAME=root
 DB_PASSWORD=root
 
+# Additional services database connection
+AS_DB_HOST=localhost
+AS_DB_PORT=3306
+AS_DB_DATABASE=as_database
+AS_DB_USERNAME=as_user
+AS_DB_PASSWORD=secret
+# Optional overrides for advanced connection settings
+# AS_DB_SOCKET=
+# AS_DB_CHARSET=utf8mb4
+# AS_DB_COLLATION=utf8mb4_unicode_ci
+# AS_DB_URL=
+# AS_DB_MYSQL_ATTR_SSL_CA=
+
 SESSION_DRIVER=database
 SESSION_LIFETIME=120
 SESSION_ENCRYPT=false

--- a/config/database.php
+++ b/config/database.php
@@ -62,6 +62,26 @@ return [
             ]) : [],
         ],
 
+        'as_db' => [
+            'driver' => 'mysql',
+            'url' => env('AS_DB_URL'),
+            'host' => env('AS_DB_HOST', '127.0.0.1'),
+            'port' => env('AS_DB_PORT', '3306'),
+            'database' => env('AS_DB_DATABASE', 'forge'),
+            'username' => env('AS_DB_USERNAME', 'forge'),
+            'password' => env('AS_DB_PASSWORD', ''),
+            'unix_socket' => env('AS_DB_SOCKET', ''),
+            'charset' => env('AS_DB_CHARSET', 'utf8mb4'),
+            'collation' => env('AS_DB_COLLATION', 'utf8mb4_unicode_ci'),
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'strict' => true,
+            'engine' => null,
+            'options' => extension_loaded('pdo_mysql') ? array_filter([
+                PDO::MYSQL_ATTR_SSL_CA => env('AS_DB_MYSQL_ATTR_SSL_CA'),
+            ]) : [],
+        ],
+
         'mariadb' => [
             'driver' => 'mariadb',
             'url' => env('DB_URL'),


### PR DESCRIPTION
## Summary
- add an `as_db` database connection configuration backed by dedicated environment variables
- document the new environment variables in `.env.example` to simplify local configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9fd8b195c8323a60b1258ee460410