### PR TITLE
Avoid persisting commission metadata in inmuebles table

### DIFF
--- a/app/Models/Inmueble.php
+++ b/app/Models/Inmueble.php
@@ -58,10 +58,6 @@ class Inmueble extends Model
         'tour_virtual_url',
         'amenidades',
         'extras',
-        'commission_percentage',
-        'commission_amount',
-        'commission_status_id',
-        'commission_status_name',
     ];
 
     protected $casts = [
@@ -78,9 +74,6 @@ class Inmueble extends Model
         'longitud' => 'decimal:7',
         'amenidades' => 'array',
         'extras' => 'array',
-        'commission_percentage' => 'decimal:2',
-        'commission_amount' => 'decimal:2',
-        'commission_status_id' => 'integer',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];


### PR DESCRIPTION
## Summary
- stop including commission fields when creating or updating inmuebles so the local table schema is respected
- keep commission data for remote sale registration and switch the connector to the configured `as_db` connection
- align the Inmueble model fillable and cast definitions with the actual database dump

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dac85a757c8323ba9dd3a2b6b3bf33