### PR TITLE
Fix venta registration lookup for ventasvillanuevagarcia

### DIFF
--- a/app/Http/Controllers/InmuebleController.php
+++ b/app/Http/Controllers/InmuebleController.php
@@ -322,9 +322,11 @@ class InmuebleController extends Controller
 
         $now = now();
         $connection = DB::connection('as_db');
+        $conceptoVenta = 'Inmueble #' . $inmueble->id;
+
         $alreadyRegistered = $connection
             ->table('ventasvillanuevagarcia')
-            ->where('inmueble_id', $inmueble->id)
+            ->where('concepto_venta', $conceptoVenta)
             ->where('mes_venta', $now->month)
             ->where('year_venta', $now->year)
             ->exists();
@@ -334,7 +336,7 @@ class InmuebleController extends Controller
         }
 
         $connection->table('ventasvillanuevagarcia')->insert([
-            'inmueble_id' => $inmueble->id,
+            'concepto_venta' => $conceptoVenta,
             'id_usuario' => 1,
             'canal_venta' => 'Inmobiliaria: ' . $inmueble->operacion,
             'comision_asesor' => 0,


### PR DESCRIPTION
## Summary
- store the inmueble identifier inside concepto_venta when registering ventasvillanuevagarcia entries
- look up existing records using concepto_venta to avoid relying on a non-existent inmueble_id column

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db0a0b73988323ba84efecfbc985fa