### PR TITLE
Ajustar concepto y monto de venta al registrar comisiones

### DIFF
--- a/app/Http/Controllers/InmuebleController.php
+++ b/app/Http/Controllers/InmuebleController.php
@@ -322,7 +322,8 @@ class InmuebleController extends Controller
 
         $now = now();
         $connection = DB::connection('as_db');
-        $conceptoVenta = 'Inmueble #' . $inmueble->id;
+        $conceptoVenta = 'Comisión inmueble #' . $inmueble->id;
+        $montoVenta = number_format($commissionAmount, 2, '.', '');
 
         $alreadyRegistered = $connection
             ->table('ventasvillanuevagarcia')
@@ -339,8 +340,9 @@ class InmuebleController extends Controller
             'concepto_venta' => $conceptoVenta,
             'id_usuario' => 1,
             'canal_venta' => 'Inmobiliaria: ' . $inmueble->operacion,
+            'monto_venta' => $montoVenta,
             'comision_asesor' => 0,
-            'ganancia_neta' => number_format($commissionAmount, 2, '.', ''),
+            'ganancia_neta' => $montoVenta,
             'mes_venta' => $now->month,
             'year_venta' => $now->year,
             'fecha_venta' => $now,


### PR DESCRIPTION
## Summary
- define un concepto de venta descriptivo y el monto bruto antes de registrar la comisión
- almacena los campos concepto_venta y monto_venta junto con el resto de la información de la venta

## Testing
- no tests


------
https://chatgpt.com/codex/tasks/task_e_68db0b5eba8c8323ab89cd09b6b16805