### PR TITLE
Auto-submit inmueble update form on status change

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1783,9 +1783,36 @@ document.addEventListener("DOMContentLoaded", () => {
             return { confirmed: true };
         };
 
+        const getInmuebleUpdateForm = () => {
+            return document.getElementById("inmueble-update-form");
+        };
+
+        const submitInmuebleUpdateForm = () => {
+            const form = getInmuebleUpdateForm();
+
+            if (!form) {
+                return;
+            }
+
+            form.dataset.submitting = "true";
+
+            if (typeof form.requestSubmit === "function") {
+                form.requestSubmit();
+            } else {
+                form.submit();
+            }
+        };
+
         const handleStatusChange = async () => {
             const selectedOption = statusSelect.selectedOptions[0] || null;
             const selectedValue = statusSelect.value || "";
+
+            const form = getInmuebleUpdateForm();
+
+            if (form?.dataset.submitting === "true") {
+                previousStatusValue = selectedValue;
+                return;
+            }
 
             if (isRestoringStatus) {
                 previousStatusValue = selectedValue;
@@ -1807,6 +1834,7 @@ document.addEventListener("DOMContentLoaded", () => {
             const result = await showCommissionModal(selectedOption);
 
             if (result.confirmed) {
+                submitInmuebleUpdateForm();
                 previousStatusValue = selectedValue;
                 return;
             }


### PR DESCRIPTION
## Summary
- add helpers to safely submit the inmueble update form when a closing status is confirmed
- prevent repeated modals by flagging the form as submitting before triggering the submission

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db23e5e5b08323b63692b9f6d0904c