### PR TITLE
Enhance status selectors and commission modal styling

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -65,12 +65,69 @@ select:focus[data-flux-control] {
     @apply size-4;
 } */
 
-select.bg-gray-850\/70 {
-    background-color: rgba(17, 24, 39, 0.7);
-    color: #f9fafb;
+.estatus-select {
+    appearance: none;
+    width: 100%;
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.92), rgba(17, 24, 39, 0.85));
+    border: 1px solid rgba(129, 140, 248, 0.35);
+    border-radius: 9999px;
+    color: #e0e7ff;
+    padding: 0.5rem 2.75rem 0.5rem 1.15rem;
+    font-weight: 600;
+    font-size: 0.875rem;
+    letter-spacing: 0.01em;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.05),
+        0 18px 40px -30px rgba(79, 70, 229, 0.65);
+    backdrop-filter: blur(12px);
 }
 
-select.bg-gray-850\/70 option {
-    background-color: #111827;
-    color: #f9fafb;
+.estatus-select:hover {
+    border-color: rgba(165, 180, 252, 0.6);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.08),
+        0 20px 45px -28px rgba(129, 140, 248, 0.55);
+}
+
+.estatus-select:focus {
+    outline: none;
+    border-color: rgba(129, 140, 248, 0.75);
+    box-shadow:
+        0 0 0 2px rgba(79, 70, 229, 0.25),
+        0 25px 55px -35px rgba(79, 70, 229, 0.7);
+}
+
+.estatus-select option {
+    background-color: #0f172a;
+    color: #e2e8f0;
+}
+
+.estatus-select::-ms-expand {
+    display: none;
+}
+
+.swal-dark-popup {
+    background: radial-gradient(circle at top, rgba(30, 41, 59, 0.95), rgba(15, 23, 42, 0.98));
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 1.75rem;
+    box-shadow:
+        0 25px 80px -35px rgba(79, 70, 229, 0.6),
+        inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    color: #e2e8f0;
+    padding: 2.75rem 2.25rem 2rem;
+}
+
+.swal-dark-title {
+    color: #f8fafc;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.swal-dark-content {
+    color: #cbd5f5;
+}
+
+.swal-dark-popup .swal2-actions {
+    margin-top: 1.75rem;
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1667,12 +1667,13 @@ document.addEventListener("DOMContentLoaded", () => {
                 confirmButtonText: "Guardar",
                 cancelButtonText: "Cancelar",
                 customClass: {
-                    popup: "bg-gray-950 text-gray-100 border border-gray-900/60 rounded-3xl",
-                    title: "text-gray-100 text-lg font-semibold",
+                    popup: "swal-dark-popup",
+                    title: "swal-dark-title",
+                    htmlContainer: "swal-dark-content",
                     confirmButton:
-                        "swal2-confirm rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400",
+                        "swal2-confirm rounded-2xl bg-indigo-500 px-6 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60",
                     cancelButton:
-                        "swal2-cancel rounded-lg bg-gray-700 px-4 py-2 text-sm font-semibold text-gray-100 transition hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500",
+                        "swal2-cancel rounded-2xl border border-white/10 bg-slate-800/70 px-6 py-2 text-sm font-semibold text-slate-200 transition hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500/60",
                 },
                 buttonsStyling: false,
                 preConfirm: () => {

--- a/resources/views/components/inmuebles/form.blade.php
+++ b/resources/views/components/inmuebles/form.blade.php
@@ -259,7 +259,7 @@
                         <select
                             id="estatus_id"
                             name="estatus_id"
-                            class="{{ $selectControlClasses }}"
+                            class="estatus-select {{ $selectControlClasses }}"
                             required
                         >
                             <option value="">Selecciona un estado</option>

--- a/resources/views/inmuebles/edit.blade.php
+++ b/resources/views/inmuebles/edit.blade.php
@@ -16,7 +16,7 @@
                                     id="estatus_id"
                                     name="estatus_id"
                                     form="inmueble-update-form"
-                                    class="appearance-none rounded-full border border-white/5 bg-gray-900/40 px-3 py-1 pr-8 text-sm font-semibold text-white shadow-sm shadow-black/30 transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/40"
+                                    class="estatus-select"
                                 >
                                     <option value="">Selecciona un estado</option>
                                     @foreach ($statuses as $status)
@@ -30,7 +30,7 @@
                                         </option>
                                     @endforeach
                                 </select>
-                                <span class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-xs text-gray-400">▾</span>
+                                <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs font-semibold text-indigo-200/80">▾</span>
                             </div>
                         </div>
                         <span class="inline-flex items-center gap-2 rounded-full bg-gray-950/70 px-3 py-1 text-gray-200">

--- a/resources/views/inmuebles/index.blade.php
+++ b/resources/views/inmuebles/index.blade.php
@@ -59,31 +59,37 @@
                 </div>
                 <div class="space-y-2">
                     <label for="operacion" class="text-sm font-medium text-gray-300">Operación</label>
-                    <select
-                        id="operacion"
-                        name="operacion"
-                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                    >
-                        <option value="">Todas</option>
-                        @foreach (\App\Models\Inmueble::OPERACIONES as $operacion)
-                            <option value="{{ $operacion }}" @selected($selectedOperacion === $operacion)>{{ $operacion }}</option>
-                        @endforeach
-                    </select>
+                    <div class="relative">
+                        <select
+                            id="operacion"
+                            name="operacion"
+                            class="estatus-select"
+                        >
+                            <option value="">Todas</option>
+                            @foreach (\App\Models\Inmueble::OPERACIONES as $operacion)
+                                <option value="{{ $operacion }}" @selected($selectedOperacion === $operacion)>{{ $operacion }}</option>
+                            @endforeach
+                        </select>
+                        <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs font-semibold text-indigo-200/80">▾</span>
+                    </div>
                 </div>
                 <div class="space-y-2">
                     <label for="estatus" class="text-sm font-medium text-gray-300">Estatus</label>
-                    <select
-                        id="estatus"
-                        name="estatus"
-                        class="w-full rounded-2xl border border-gray-700 bg-gray-850/70 px-4 py-3 text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                    >
-                        <option value="">Todos</option>
-                        @foreach ($statuses as $status)
-                            <option value="{{ $status->id }}" @selected((string) $selectedStatus === (string) $status->id)>
-                                {{ $status->nombre }} ({{ $status->inmuebles_count }})
-                            </option>
-                        @endforeach
-                    </select>
+                    <div class="relative">
+                        <select
+                            id="estatus"
+                            name="estatus"
+                            class="estatus-select"
+                        >
+                            <option value="">Todos</option>
+                            @foreach ($statuses as $status)
+                                <option value="{{ $status->id }}" @selected((string) $selectedStatus === (string) $status->id)>
+                                    {{ $status->nombre }} ({{ $status->inmuebles_count }})
+                                </option>
+                            @endforeach
+                        </select>
+                        <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs font-semibold text-indigo-200/80">▾</span>
+                    </div>
                 </div>
                 <div class="flex items-end gap-3">
                     <button type="submit" class="w-full rounded-2xl bg-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400">


### PR DESCRIPTION
## Summary
- restyle the status dropdown badges to better match the admin dashboard aesthetic
- apply the updated selector look to listing filters for consistency
- theme the commission SweetAlert popup with a darker palette and polished button styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db25e5b640832393442ec39c086060