### PR TITLE
Restringe destacado a estatus disponibles

### DIFF
--- a/app/Http/Controllers/InmuebleController.php
+++ b/app/Http/Controllers/InmuebleController.php
@@ -137,6 +137,12 @@ class InmuebleController extends Controller
             $payload['estatus_id'] = 1;
         }
 
+        $targetStatusId = isset($payload['estatus_id']) ? (int) $payload['estatus_id'] : null;
+
+        if (! InmuebleStatusClassifier::isAvailableStatusId($targetStatusId)) {
+            $payload['destacado'] = false;
+        }
+
         $this->extractCommissionData($payload);
 
         DB::transaction(function () use ($payload, $imagenes): void {
@@ -178,6 +184,11 @@ class InmuebleController extends Controller
 
         $originalStatusId = (int) $inmueble->estatus_id;
         $newStatusId = isset($payload['estatus_id']) ? (int) $payload['estatus_id'] : $originalStatusId;
+
+        if (! InmuebleStatusClassifier::isAvailableStatusId($newStatusId)) {
+            $payload['destacado'] = false;
+        }
+
         $isClosingStatus = InmuebleStatusClassifier::isClosingStatusId($newStatusId);
         $wasClosingStatus = InmuebleStatusClassifier::isClosingStatusId($originalStatusId);
         $isTransitionToClosing = $isClosingStatus && ! $wasClosingStatus;

--- a/database/factories/InmuebleFactory.php
+++ b/database/factories/InmuebleFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\Inmueble;
 use App\Models\InmuebleStatus;
 use App\Models\User;
+use App\Support\InmuebleStatusClassifier;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -39,7 +40,9 @@ class InmuebleFactory extends Factory
             'banos' => $this->faker->numberBetween(1, 4),
             'estacionamientos' => $this->faker->numberBetween(0, 3),
             'metros_cuadrados' => $this->faker->randomFloat(2, 40, 500),
-            'destacado' => $this->faker->boolean(),
+            'destacado' => InmuebleStatusClassifier::isAvailableStatusName($status->nombre)
+                ? $this->faker->boolean()
+                : false,
         ];
     }
 }


### PR DESCRIPTION
## Summary
- agrega utilidades para detectar estatus disponibles mediante nombre normalizado
- obliga a que los inmuebles solo queden destacados cuando el estatus destino es disponible
- ajusta la fábrica de inmuebles para respetar la misma regla

## Testing
- No se ejecutaron pruebas (no solicitadas)


------
https://chatgpt.com/codex/tasks/task_e_68db418f7cf88323b22ed2483b0e987e