### PR TITLE
Ajustar cinta de estatus para inmuebles no disponibles

### DIFF
--- a/resources/views/inmuebles/index.blade.php
+++ b/resources/views/inmuebles/index.blade.php
@@ -113,12 +113,19 @@
                 @foreach ($inmuebles as $inmueble)
                     <article class="flex flex-col overflow-hidden rounded-3xl border border-gray-800 bg-gray-900/70 shadow-xl shadow-black/30 transition hover:-translate-y-1 hover:border-indigo-500/60">
                         <div class="relative h-56 w-full overflow-hidden">
-                            @if (\App\Support\InmuebleStatusClassifier::isClosingStatusId($inmueble->estatus_id))
+                            @php
+                                $isAvailableStatus = \App\Support\InmuebleStatusClassifier::isAvailableStatusId($inmueble->estatus_id);
+                                $normalizedStatus = \Illuminate\Support\Str::of($inmueble->status->nombre ?? '')->lower()->squish()->value();
+                                $isRentadoOVendido = in_array($normalizedStatus, ['rentado', 'vendido'], true);
+                                $ribbonBackground = $isRentadoOVendido ? '#a5c71b' : ($inmueble->status->color ?? '#1f2937');
+                                $ribbonTextClasses = $isRentadoOVendido ? 'text-gray-900 font-bold' : 'text-white font-semibold';
+                            @endphp
+                            @if (! $isAvailableStatus)
                                 <span
-                                    class="absolute top-5 left-[-36px] w-[170px] rotate-[-12deg] px-6 py-2 text-center text-[11px] font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-black/20 md:top-6 md:left-[-40px] md:w-[190px] md:rotate-[-14deg] md:text-xs lg:top-8 lg:left-[-48px] lg:w-[210px] lg:rotate-[-16deg]"
-                                    style="background-color: {{ $inmueble->status->color }}"
+                                    class="absolute top-5 left-[-36px] w-[170px] rotate-[-12deg] px-6 py-2 text-center text-[11px] uppercase tracking-[0.3em] shadow-lg shadow-black/20 md:top-6 md:left-[-40px] md:w-[190px] md:rotate-[-14deg] md:text-xs lg:top-8 lg:left-[-48px] lg:w-[210px] lg:rotate-[-16deg] {{ $ribbonTextClasses }}"
+                                    style="background-color: {{ $ribbonBackground }}"
                                 >
-                                    Cierre en proceso
+                                    {{ $inmueble->status->nombre }}
                                 </span>
                             @endif
                             @if ($inmueble->coverImage)


### PR DESCRIPTION
## Summary
- mostrar la cinta de estatus cuando el inmueble no está disponible usando el clasificador existente
- ajustar el texto y estilos de la cinta para rentado/vendido y reutilizar los colores del catálogo en otros casos

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db4348c2b08323864d54ea60e0cdb8