### PR TITLE
Add SweetAlert loader to property edit form

### DIFF
--- a/resources/views/inmuebles/edit.blade.php
+++ b/resources/views/inmuebles/edit.blade.php
@@ -66,6 +66,9 @@
             method="POST"
             enctype="multipart/form-data"
             class="space-y-8"
+            data-swal-loader="actualizar-inmueble"
+            data-swal-loader-title="Guardando cambios"
+            data-swal-loader-text="Estamos aplicando las actualizaciones del inmueble..."
         >
             @csrf
             @method('PUT')


### PR DESCRIPTION
## Summary
- display a SweetAlert loader when submitting the property edit form so users see feedback during updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db621249a483238ac3f7af5e1045c3