### PR TITLE
Submit inmueble update form for non-closing status changes

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1899,6 +1899,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
             if (!isClosingStatus(selectedOption)) {
                 updateHiddenCommissionFields("", "", "", "");
+                submitInmuebleUpdateForm();
                 previousStatusValue = selectedValue;
                 return;
             }


### PR DESCRIPTION
## Summary
- submit the inmueble update form when choosing a status that does not require commission
- keep the existing confirmation flow for statuses that do require a commission before submitting the form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db6743dc1c8323be93d9a8bbe5da76