### PR TITLE
Adjust Swal loader flag handling

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1313,10 +1313,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
     document.querySelectorAll("form[data-swal-loader]").forEach((form) => {
         form.addEventListener("submit", () => {
-            if (!window.Swal || form.dataset.submitting === "true") {
+            if (!window.Swal || form.dataset.swalLoaderActive === "true") {
                 return;
             }
 
+            form.dataset.swalLoaderActive = "true";
             form.dataset.submitting = "true";
 
             const title = form.dataset.swalLoaderTitle || "Registrando contacto";


### PR DESCRIPTION
## Summary
- prevent duplicate SweetAlert loaders by checking a dedicated dataset flag
- mark the new flag when firing the loader while preserving the submitting guard

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68db682921688323ac6f37a07da10a29