### PR TITLE
Add status metadata to property map markers

### DIFF
--- a/app/Http/Controllers/InmuebleController.php
+++ b/app/Http/Controllers/InmuebleController.php
@@ -89,11 +89,15 @@ class InmuebleController extends Controller
         $properties = Inmueble::query()
             ->whereNotNull('latitud')
             ->whereNotNull('longitud')
-            ->with('coverImage')
+            ->with(['coverImage', 'status'])
             ->get()
             ->map(function (Inmueble $inmueble): array {
                 $coverImage = $inmueble->coverImage;
                 $imageUrl = $coverImage?->temporaryVariantUrl('watermarked') ?? $coverImage?->url;
+                $status = $inmueble->status;
+                $statusId = $inmueble->estatus_id !== null
+                    ? (int) $inmueble->estatus_id
+                    : null;
 
                 return [
                     'id' => $inmueble->id,
@@ -104,6 +108,13 @@ class InmuebleController extends Controller
                     'price' => $inmueble->formattedPrice(),
                     'image_url' => $imageUrl,
                     'manage_url' => route('inmuebles.edit', $inmueble),
+                    'status' => $status
+                        ? [
+                            'name' => $status->nombre,
+                            'color' => $status->color,
+                        ]
+                        : null,
+                    'is_available' => InmuebleStatusClassifier::isAvailableStatusId($statusId),
                 ];
             })
             ->values();

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -131,3 +131,59 @@ select:focus[data-flux-control] {
 .swal-dark-popup .swal2-actions {
     margin-top: 1.75rem;
 }
+
+.property-status-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.65rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1;
+    color: #ffffff;
+    box-shadow: 0 8px 18px -10px rgba(15, 23, 42, 0.35);
+}
+
+.property-marker {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.property-marker--available {
+    position: relative;
+    width: 30px;
+    height: 42px;
+    background: transparent;
+    border: none;
+}
+
+.property-marker--available::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, 0);
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #22c55e;
+    border: 3px solid #ffffff;
+    box-shadow: 0 6px 16px rgba(34, 197, 94, 0.45);
+}
+
+.property-marker--available::after {
+    content: "";
+    position: absolute;
+    bottom: 2px;
+    left: 50%;
+    transform: translate(-50%, 0);
+    width: 0;
+    height: 0;
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+    border-top: 14px solid #22c55e;
+    filter: drop-shadow(0 2px 4px rgba(15, 23, 42, 0.35));
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -199,10 +199,16 @@ document.addEventListener("DOMContentLoaded", () => {
         }).addTo(map);
 
         const bounds = L.latLngBounds();
+        const availableMarkerIcon = L.divIcon({
+            className: "property-marker property-marker--available",
+            iconSize: [30, 42],
+            iconAnchor: [15, 42],
+            popupAnchor: [0, -32],
+        });
 
         properties.forEach((property) => {
             const position = [property.latitude, property.longitude];
-            const marker = L.marker(position).addTo(map);
+            const marker = L.marker(position, property?.is_available ? { icon: availableMarkerIcon } : {}).addTo(map);
 
             bounds.extend(position);
 
@@ -211,20 +217,39 @@ document.addEventListener("DOMContentLoaded", () => {
             const title = escapeHtml(property.title ?? "Inmueble");
             const address = escapeHtml(property.address ?? "");
             const price = escapeHtml(property.price ?? "");
+            const statusNameRaw =
+                property?.status && typeof property.status.name === "string"
+                    ? property.status.name
+                    : "";
+            const statusColorRaw =
+                property?.status && typeof property.status.color === "string"
+                    ? property.status.color
+                    : "";
+            const statusName = escapeHtml(statusNameRaw);
+            const statusColor = statusColorRaw.trim();
+            const statusBadgeStyle = statusColor
+                ? ` style="background-color: ${escapeHtml(statusColor)}"`
+                : "";
+            const statusBadge = statusName
+                ? `<span class="property-status-badge"${statusBadgeStyle}>${statusName}</span>`
+                : "";
 
             const imageContent = imageUrl
                 ? `<img src="${imageUrl}" alt="${title}" class="mb-3 h-32 w-full rounded-lg object-cover" />`
                 : "";
 
             const manageButton = manageUrl
-                ? `<a href="${manageUrl}" class="mt-3 inline-flex w-full items-center justify-center rounded-lg bg-indigo-600 px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-500">Gestionar inmueble</a>`
+                ? `<a href="${manageUrl}" class="mt-3 inline-flex w-full items-center justify-center rounded-lg bg-indigo-600 px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500">Gestionar inmueble</a>`
                 : "";
 
             const popupContent = `
                 <div class="space-y-3 text-left">
                     ${imageContent}
                     <div>
-                        <h3 class="text-base font-semibold text-gray-900">${title}</h3>
+                        <div class="flex items-center justify-between gap-2">
+                            <h3 class="text-base font-semibold text-gray-900">${title}</h3>
+                            ${statusBadge}
+                        </div>
                         <p class="text-sm text-gray-600">${address}</p>
                         <p class="text-sm font-semibold text-indigo-600">${price}</p>
                     </div>


### PR DESCRIPTION
## Summary
- load each property's status when building the map payload and expose the status name, color, and availability flag
- render the status badge and adjust marker appearance based on availability in the map frontend
- add CSS helpers to style the status badge and available marker pin

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db6a8bc83c8323bb466b027c0c77f9