### PR TITLE
Fix map manage button text color override

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -187,3 +187,10 @@ select:focus[data-flux-control] {
     border-top: 14px solid #22c55e;
     filter: drop-shadow(0 2px 4px rgba(15, 23, 42, 0.35));
 }
+
+.leaflet-popup-content .manage-property-button,
+.leaflet-popup-content .manage-property-button:visited,
+.leaflet-popup-content .manage-property-button:hover,
+.leaflet-popup-content .manage-property-button:focus {
+    color: #ffffff;
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -252,11 +252,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 : "";
 
             const manageButton = manageUrl
-                ? `<a href="${manageUrl}" class="mt-3 w-full inline-flex items-center justify-center rounded-xl 
-         bg-indigo-600/90 px-4 py-2.5 text-sm font-medium text-white 
-         shadow-[0_8px_20px_rgba(79,70,229,0.35)] 
-         hover:bg-indigo-500/90 hover:shadow-[0_6px_16px_rgba(79,70,229,0.45)] 
-         focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/70 
+                ? `<a href="${manageUrl}" class="manage-property-button mt-3 w-full inline-flex items-center justify-center rounded-xl
+         bg-indigo-600/90 px-4 py-2.5 text-sm font-medium text-white
+         shadow-[0_8px_20px_rgba(79,70,229,0.35)]
+         hover:bg-indigo-500/90 hover:shadow-[0_6px_16px_rgba(79,70,229,0.45)]
+         focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/70
          transition-all duration-300 ease-out">Gestionar inmueble</a>`
                 : "";
 


### PR DESCRIPTION
## Summary
- add a dedicated class to the "Gestionar inmueble" link generated in the map popup
- override the Leaflet styles so the manage button keeps white text regardless of link states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db709e5a948323ba329b7d21091001