### PR TITLE
Limit postal resolve params to type and value

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -525,14 +525,6 @@ document.addEventListener("DOMContentLoaded", () => {
                 value: addressDetails[selectedType],
             });
 
-            typePriority.forEach((key) => {
-                if (!addressDetails[key]) {
-                    return;
-                }
-
-                params.set(key, addressDetails[key]);
-            });
-
             try {
                 const response = await fetch(
                     `${resolveUrl}?${params.toString()}`,


### PR DESCRIPTION
## Summary
- stop appending colonia, municipio, or estado filters to postal resolution requests
- ensure codigo_postal requests only include the postal code value while preserving fallback population

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db78bf3d908323b49a43254a981ec5