### PR TITLE
Filtrar inmuebles disponibles en registro de contactos

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Contact;
 use App\Models\Inmueble;
+use App\Support\InmuebleStatusClassifier;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -73,7 +74,11 @@ class ContactController extends Controller
                 'banos',
                 'estacionamientos',
                 'metros_cuadrados',
+                'estatus_id',
             ])
+            ->filter(static function (Inmueble $inmueble) {
+                return InmuebleStatusClassifier::isAvailableStatusId($inmueble->estatus_id);
+            })
             ->map(function (Inmueble $inmueble) {
                 $coverImage = $inmueble->coverImage;
 
@@ -83,7 +88,8 @@ class ContactController extends Controller
                 );
 
                 return $inmueble;
-            });
+            })
+            ->values();
 
         return view('contacts.create', [
             'prefill' => $prefillValue,


### PR DESCRIPTION
## Summary
- Filtrar la lista de inmuebles en el formulario de registro de contactos para mostrar solo los que tienen un estatus disponible
- Mantener la información de portada de los inmuebles disponibles

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db8c0640e8832393d628b1179f18aa