### PR TITLE
Adjust Leaflet control z-index

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -194,3 +194,8 @@ select:focus[data-flux-control] {
 .leaflet-popup-content .manage-property-button:focus {
     color: #ffffff;
 }
+
+.leaflet-top,
+.leaflet-bottom {
+    z-index: 500 !important;
+}


### PR DESCRIPTION
## Summary
- lower the stacking context of Leaflet control containers to sit beneath modal overlays by default

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68ddeaad0fc4832391a639192da1f995